### PR TITLE
fix: better getNumTwoBit

### DIFF
--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -47,7 +47,8 @@ let Utils = {
 	 * @return {string}
 	 */
 	getNumTwoBit: function(n) {
-	    return (n > 9 ? '' : '0') + n;
+	    const nn = Number(n);
+	    return (nn > 9 ? '' : '0') + nn;
 	},
 
 	/**


### PR DESCRIPTION
`getNumTwoBit`传递`03`会返回`003`，导致`calendar`组件中`getCurrDate`方法有可能获取到类似`2019-06-003`这样的数据。

在chrome测试没有出错，我想是因为
```
// Utils.compareDate
new Date('2019-06-003'.replace('-', '/').replace('-', '/')) >= new Date('2019-06-03'.replace('-', '/').replace('-', '/')) // true
```
所以
```
// 遇到2019-06-003，getClass返回了null，使得逻辑能顺利往下走
this.getClass(day, month, isRange) != `${this.dayPrefix}-disabled` // calendar.vue第210行 
```
