### PR TITLE
fix: 修复nut-elevator嵌套Popup或ActionSheet中,iOS端不显示问题

### DIFF
--- a/src/packages/elevator/elevator.scss
+++ b/src/packages/elevator/elevator.scss
@@ -1,5 +1,5 @@
 .nut-elevator{
-    position: fixed;
+    position:relative;
     top:40px;
     width: 100%;
 }


### PR DESCRIPTION
.nut-elevator 
position: fixed; => position:relative;