### PR TITLE
fix(pxCheck): typeof number check

### DIFF
--- a/src/utils/pxCheck.ts
+++ b/src/utils/pxCheck.ts
@@ -1,3 +1,3 @@
-export const pxCheck = (value: string | number) => {
-  return typeof Number(value) === 'number' ? `${value}px` : String(value);
+export const pxCheck = (value: string | number): string => {
+  return isNaN(Number(value)) ? String(value) : `${value}px`;
 };


### PR DESCRIPTION
条件'typeof Number（value）==='number'始终为true,  使用 `isNaN` 代替。