### PR TITLE
docs: 优化Price组件前后加符号，可不保留小数点

### DIFF
--- a/src/packages/__VUE/price/doc.md
+++ b/src/packages/__VUE/price/doc.md
@@ -62,4 +62,5 @@ setup() {
 | symbol         | 符号类型                 | String  | &yen;  |
 | decimal-digits | 小数位位数               | Number  | 2      |
 | thousands      | 是否按照千分号形式显示   | Boolean | false  |
-| before-or-after      | 符号显示在（价格）前或者后   | String | before  |
+| position      | 符号显示在(价格)前或者后(before、after)   | String | before  |
+| font-size      | 价格尺寸(big、medium、small)   | String | big  |

--- a/src/packages/__VUE/price/doc.md
+++ b/src/packages/__VUE/price/doc.md
@@ -62,3 +62,4 @@ setup() {
 | symbol         | 符号类型                 | String  | &yen;  |
 | decimal-digits | 小数位位数               | Number  | 2      |
 | thousands      | 是否按照千分号形式显示   | Boolean | false  |
+| before-or-after      | 符号显示在（价格）前或者后   | String | before  |

--- a/src/packages/__VUE/price/doc.md
+++ b/src/packages/__VUE/price/doc.md
@@ -63,4 +63,4 @@ setup() {
 | decimal-digits | 小数位位数               | Number  | 2      |
 | thousands      | 是否按照千分号形式显示   | Boolean | false  |
 | position      | 符号显示在(价格)前或者后(before、after)   | String | before  |
-| font-size      | 价格尺寸(big、medium、small)   | String | big  |
+| size      | 价格尺寸(large、normal、small)   | String | normal  |

--- a/src/packages/__VUE/price/index.scss
+++ b/src/packages/__VUE/price/index.scss
@@ -5,9 +5,9 @@
   &--symbol {
     display: inline-block;
     font-size: $font-size-3;
-    margin-right: 4px;
+    // margin-right: 4px;
   }
-  &--big {
+  &--large {
     display: inline-block;
     font-size: $price-big-size;
   }
@@ -20,23 +20,23 @@
   //   font-size: $font-size-4;
   // }
 
-  &--decimal-big {
+  &--decimal-large {
     display: inline-block;
     font-size: $price-decimal-big-size;
   }
-  &--symbol-big {
+  &--symbol-large {
     display: inline-block;
     font-size: $price-symbol-big-size;
   }
-  &--medium {
+  &--normal {
     display: inline-block;
     font-size: $price-medium-size;
   }
-  &--decimal-medium {
+  &--decimal-normal {
     display: inline-block;
     font-size: $price-decimal-medium-size;
   }
-  &--symbol-medium {
+  &--symbol-normal {
     display: inline-block;
     font-size: $price-symbol-medium-size;
   }

--- a/src/packages/__VUE/price/index.scss
+++ b/src/packages/__VUE/price/index.scss
@@ -15,8 +15,45 @@
     display: inline-block;
     font-size: $price-big-size;
   }
+  // &--small {
+  //   display: inline-block;
+  //   font-size: $font-size-4;
+  // }
+
+  &--decimal-big {
+    display: inline-block;
+    font-size: $price-decimal-big-size;
+  }
+  &--symbol-big {
+    display: inline-block;
+    font-size: $price-symbol-big-size;
+  }
+  &--medium {
+    display: inline-block;
+    font-size: $price-medium-size;
+  }
+  &--decimal-medium {
+    display: inline-block;
+    font-size: $price-decimal-medium-size;
+  }
+  &--symbol-medium {
+    display: inline-block;
+    font-size: $price-symbol-medium-size;
+  }
   &--small {
     display: inline-block;
-    font-size: $font-size-4;
+    font-size: $price-small-size;
   }
+  &--decimal-small {
+    display: inline-block;
+    font-size: $price-decimal-small-size;
+  }
+  &--symbol-small {
+    display: inline-block;
+    font-size: $price-symbol-small-size;
+  }
+  // &--decimal--big {
+  //   display: inline-block;
+  //   font-size: $price-medium-size;
+  // }
 }

--- a/src/packages/__VUE/price/index.taro.vue
+++ b/src/packages/__VUE/price/index.taro.vue
@@ -1,18 +1,23 @@
 <template>
-  <view :class="classes">
-    <view
-      v-if="needSymbol"
-      class="nut-price--symbol"
-      decode="true"
-      v-html="showSymbol"
-    ></view>
+  <view :class="classes" v-if="beforeOrAfter == 'before'">
+    <view v-if="needSymbol" class="nut-price--symbol" decode="true" v-html="showSymbol"></view>
     <view class="nut-price--big">
       {{ formatThousands(price) }}
     </view>
-    <view class="nut-price--point">.</view>
+    <view class="nut-price--point" v-if="decimalDigits != 0">.</view>
     <view class="nut-price--small">
       {{ formatDecimal(price) }}
     </view>
+  </view>
+  <view :class="classes" v-if="beforeOrAfter == 'after'">
+    <view class="nut-price--big">
+      {{ formatThousands(price) }}
+    </view>
+    <view class="nut-price--point" v-if="decimalDigits != 0">.</view>
+    <view class="nut-price--small">
+      {{ formatDecimal(price) }}
+    </view>
+    <view v-if="needSymbol" class="nut-price--symbol" decode="true" v-html="showSymbol"></view>
   </view>
 </template>
 
@@ -42,6 +47,10 @@ export default create({
     thousands: {
       type: Boolean,
       default: false
+    },
+    beforeOrAfter: {
+      type: String,
+      default: 'before'
     }
   },
 
@@ -74,10 +83,7 @@ export default create({
       }
       if (checkPoint(num)) {
         num = Number(num).toFixed(props.decimalDigits);
-        num =
-          typeof num.split('.') === 'string'
-            ? num.split('.')
-            : num.split('.')[0];
+        num = typeof num.split('.') === 'string' ? num.split('.') : num.split('.')[0];
       } else {
         num = num.toString();
       }
@@ -94,9 +100,7 @@ export default create({
       if (checkPoint(decimalNum)) {
         decimalNum = Number(decimalNum).toFixed(props.decimalDigits);
         decimalNum =
-          typeof decimalNum.split('.') === 'string'
-            ? 0
-            : decimalNum.split('.')[1];
+          typeof decimalNum.split('.') === 'string' ? 0 : decimalNum.split('.')[1] ? decimalNum.split('.')[1] : 0;
       } else {
         decimalNum = 0;
       }

--- a/src/packages/__VUE/price/index.taro.vue
+++ b/src/packages/__VUE/price/index.taro.vue
@@ -1,23 +1,26 @@
 <template>
-  <view :class="classes" v-if="beforeOrAfter == 'before'">
-    <view v-if="needSymbol" class="nut-price--symbol" decode="true" v-html="showSymbol"></view>
-    <view class="nut-price--big">
+  <view :class="classes">
+    <view
+      v-if="needSymbol && position == 'before'"
+      class="nut-price--symbol"
+      :class="`nut-price--symbol-${fontSize}`"
+      decode="true"
+      v-html="showSymbol"
+    ></view>
+    <view :class="`nut-price--${fontSize}`">
       {{ formatThousands(price) }}
     </view>
-    <view class="nut-price--point" v-if="decimalDigits != 0">.</view>
-    <view class="nut-price--small">
+    <view :class="`nut-price--decimal-${fontSize}`" v-if="decimalDigits != 0">.</view>
+    <view :class="`nut-price--decimal-${fontSize}`">
       {{ formatDecimal(price) }}
     </view>
-  </view>
-  <view :class="classes" v-if="beforeOrAfter == 'after'">
-    <view class="nut-price--big">
-      {{ formatThousands(price) }}
-    </view>
-    <view class="nut-price--point" v-if="decimalDigits != 0">.</view>
-    <view class="nut-price--small">
-      {{ formatDecimal(price) }}
-    </view>
-    <view v-if="needSymbol" class="nut-price--symbol" decode="true" v-html="showSymbol"></view>
+    <view
+      v-if="needSymbol && position == 'after'"
+      class="nut-price--symbol"
+      :class="`nut-price--symbol-${fontSize}`"
+      decode="true"
+      v-html="showSymbol"
+    ></view>
   </view>
 </template>
 
@@ -48,9 +51,13 @@ export default create({
       type: Boolean,
       default: false
     },
-    beforeOrAfter: {
+    position: {
       type: String,
       default: 'before'
+    },
+    fontSize: {
+      type: String,
+      default: 'big'
     }
   },
 

--- a/src/packages/__VUE/price/index.taro.vue
+++ b/src/packages/__VUE/price/index.taro.vue
@@ -3,21 +3,21 @@
     <view
       v-if="needSymbol && position == 'before'"
       class="nut-price--symbol"
-      :class="`nut-price--symbol-${fontSize}`"
+      :class="`nut-price--symbol-${size}`"
       decode="true"
       v-html="showSymbol"
     ></view>
-    <view :class="`nut-price--${fontSize}`">
+    <view :class="`nut-price--${size}`">
       {{ formatThousands(price) }}
     </view>
-    <view :class="`nut-price--decimal-${fontSize}`" v-if="decimalDigits != 0">.</view>
-    <view :class="`nut-price--decimal-${fontSize}`">
+    <view :class="`nut-price--decimal-${size}`" v-if="decimalDigits != 0">.</view>
+    <view :class="`nut-price--decimal-${size}`">
       {{ formatDecimal(price) }}
     </view>
     <view
       v-if="needSymbol && position == 'after'"
       class="nut-price--symbol"
-      :class="`nut-price--symbol-${fontSize}`"
+      :class="`nut-price--symbol-${size}`"
       decode="true"
       v-html="showSymbol"
     ></view>
@@ -55,9 +55,9 @@ export default create({
       type: String,
       default: 'before'
     },
-    fontSize: {
+    size: {
       type: String,
-      default: 'big'
+      default: 'normal'
     }
   },
 

--- a/src/packages/__VUE/price/index.vue
+++ b/src/packages/__VUE/price/index.vue
@@ -1,17 +1,23 @@
 <template>
-  <view :class="classes">
-    <view
-      v-if="needSymbol"
-      class="nut-price--symbol"
-      v-html="showSymbol"
-    ></view>
+  <view :class="classes" v-if="beforeOrAfter == 'before'">
+    <view v-if="needSymbol" class="nut-price--symbol" v-html="showSymbol"></view>
     <view class="nut-price--big">
       {{ formatThousands(price) }}
     </view>
-    <view class="nut-price--point">.</view>
+    <view class="nut-price--point" v-if="decimalDigits != 0">.</view>
     <view class="nut-price--small">
       {{ formatDecimal(price) }}
     </view>
+  </view>
+  <view :class="classes" v-if="beforeOrAfter == 'after'">
+    <view class="nut-price--big">
+      {{ formatThousands(price) }}
+    </view>
+    <view class="nut-price--point" v-if="decimalDigits != 0">.</view>
+    <view class="nut-price--small">
+      {{ formatDecimal(price) }}
+    </view>
+    <view v-if="needSymbol" class="nut-price--symbol" v-html="showSymbol"></view>
   </view>
 </template>
 
@@ -41,6 +47,10 @@ export default create({
     thousands: {
       type: Boolean,
       default: false
+    },
+    beforeOrAfter: {
+      type: String,
+      default: 'before'
     }
   },
 
@@ -64,10 +74,7 @@ export default create({
       }
       if (checkPoint(num)) {
         num = Number(num).toFixed(props.decimalDigits);
-        num =
-          typeof num.split('.') === 'string'
-            ? num.split('.')
-            : num.split('.')[0];
+        num = typeof num.split('.') === 'string' ? num.split('.') : num.split('.')[0];
       } else {
         num = num.toString();
       }
@@ -84,9 +91,7 @@ export default create({
       if (checkPoint(decimalNum)) {
         decimalNum = Number(decimalNum).toFixed(props.decimalDigits);
         decimalNum =
-          typeof decimalNum.split('.') === 'string'
-            ? 0
-            : decimalNum.split('.')[1];
+          typeof decimalNum.split('.') === 'string' ? 0 : decimalNum.split('.')[1] ? decimalNum.split('.')[1] : 0;
       } else {
         decimalNum = 0;
       }

--- a/src/packages/__VUE/price/index.vue
+++ b/src/packages/__VUE/price/index.vue
@@ -3,20 +3,20 @@
     <view
       v-if="needSymbol && position == 'before'"
       class="nut-price--symbol"
-      :class="`nut-price--symbol-${fontSize}`"
+      :class="`nut-price--symbol-${size}`"
       v-html="showSymbol"
     ></view>
-    <view :class="`nut-price--${fontSize}`">
+    <view :class="`nut-price--${size}`">
       {{ formatThousands(price) }}
     </view>
-    <view :class="`nut-price--decimal-${fontSize}`" v-if="decimalDigits != 0">.</view>
-    <view :class="`nut-price--decimal-${fontSize}`">
+    <view :class="`nut-price--decimal-${size}`" v-if="decimalDigits != 0">.</view>
+    <view :class="`nut-price--decimal-${size}`">
       {{ formatDecimal(price) }}
     </view>
     <view
       v-if="needSymbol && position == 'after'"
       class="nut-price--symbol"
-      :class="`nut-price--symbol-${fontSize}`"
+      :class="`nut-price--symbol-${size}`"
       v-html="showSymbol"
     ></view>
   </view>
@@ -53,9 +53,9 @@ export default create({
       type: String,
       default: 'before'
     },
-    fontSize: {
+    size: {
       type: String,
-      default: 'big'
+      default: 'normal'
     }
   },
 

--- a/src/packages/__VUE/price/index.vue
+++ b/src/packages/__VUE/price/index.vue
@@ -1,23 +1,24 @@
 <template>
-  <view :class="classes" v-if="beforeOrAfter == 'before'">
-    <view v-if="needSymbol" class="nut-price--symbol" v-html="showSymbol"></view>
-    <view class="nut-price--big">
+  <view :class="classes">
+    <view
+      v-if="needSymbol && position == 'before'"
+      class="nut-price--symbol"
+      :class="`nut-price--symbol-${fontSize}`"
+      v-html="showSymbol"
+    ></view>
+    <view :class="`nut-price--${fontSize}`">
       {{ formatThousands(price) }}
     </view>
-    <view class="nut-price--point" v-if="decimalDigits != 0">.</view>
-    <view class="nut-price--small">
+    <view :class="`nut-price--decimal-${fontSize}`" v-if="decimalDigits != 0">.</view>
+    <view :class="`nut-price--decimal-${fontSize}`">
       {{ formatDecimal(price) }}
     </view>
-  </view>
-  <view :class="classes" v-if="beforeOrAfter == 'after'">
-    <view class="nut-price--big">
-      {{ formatThousands(price) }}
-    </view>
-    <view class="nut-price--point" v-if="decimalDigits != 0">.</view>
-    <view class="nut-price--small">
-      {{ formatDecimal(price) }}
-    </view>
-    <view v-if="needSymbol" class="nut-price--symbol" v-html="showSymbol"></view>
+    <view
+      v-if="needSymbol && position == 'after'"
+      class="nut-price--symbol"
+      :class="`nut-price--symbol-${fontSize}`"
+      v-html="showSymbol"
+    ></view>
   </view>
 </template>
 
@@ -48,9 +49,13 @@ export default create({
       type: Boolean,
       default: false
     },
-    beforeOrAfter: {
+    position: {
       type: String,
       default: 'before'
+    },
+    fontSize: {
+      type: String,
+      default: 'big'
     }
   },
 

--- a/src/packages/styles/variables.scss
+++ b/src/packages/styles/variables.scss
@@ -149,20 +149,20 @@ $shortpsd-border-color: #ddd !default;
 $shortpsd-error: rgba(242, 39, 12, 1) !default;
 $shortpsd-forget: rgba(128, 128, 128, 1) !default;
 
-//big price
-$price-big-size: 24px !default;
-$price-decimal-big-size: 16px !default;
+//large price
 $price-symbol-big-size: 16px !default;
+$price-big-size: 30px !default;
+$price-decimal-big-size: 18px !default;
 
-//medium price
+//normal price
+$price-symbol-medium-size: 13px !default;
 $price-medium-size: 16px !default;
-$price-decimal-medium-size: 9.88px !default;
-$price-symbol-medium-size: 9.88px !default;
+$price-decimal-medium-size: 13px !default;
 
 // small price
-$price-small-size: 13px !default;
-$price-decimal-small-size: 8.125px !default;
-$price-symbol-small-size: 10.4px !default;
+$price-symbol-small-size: 11px !default;
+$price-small-size: 14.2px !default;
+$price-decimal-small-size: 14.2px !default;
 
 //avatar
 $avatar-square: 5px !default;

--- a/src/packages/styles/variables.scss
+++ b/src/packages/styles/variables.scss
@@ -149,8 +149,20 @@ $shortpsd-border-color: #ddd !default;
 $shortpsd-error: rgba(242, 39, 12, 1) !default;
 $shortpsd-forget: rgba(128, 128, 128, 1) !default;
 
-//price
+//big price
 $price-big-size: 24px !default;
+$price-decimal-big-size: 16px !default;
+$price-symbol-big-size: 16px !default;
+
+//medium price
+$price-medium-size: 16px !default;
+$price-decimal-medium-size: 9.88px !default;
+$price-symbol-medium-size: 9.88px !default;
+
+// small price
+$price-small-size: 13px !default;
+$price-decimal-small-size: 8.125px !default;
+$price-symbol-small-size: 10.4px !default;
 
 //avatar
 $avatar-square: 5px !default;

--- a/src/sites/mobile-taro/vue/src/base/pages/price/index.vue
+++ b/src/sites/mobile-taro/vue/src/base/pages/price/index.vue
@@ -10,21 +10,11 @@
     </nut-cell>
     <h2>带人民币符号，有千位分隔，保留小数点后三位</h2>
     <nut-cell>
-      <nut-price
-        :price="15213.1221"
-        :decimal-digits="3"
-        :need-symbol="true"
-        :thousands="true"
-      />
+      <nut-price :price="15213.1221" :decimal-digits="2" :need-symbol="true" :thousands="true" />
     </nut-cell>
     <h2>异步随机变更</h2>
     <nut-cell>
-      <nut-price
-        :price="price"
-        :decimal-digits="3"
-        :need-symbol="false"
-        :thousands="true"
-      />
+      <nut-price :price="price" :decimal-digits="3" :need-symbol="false" :thousands="true" />
     </nut-cell>
   </div>
 </template>


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://nutui.jd.com/#/contributing
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)



**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] NutUI 2.0
- [x] NutUI 3.0 H5
- [x] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [ ] 自测 vue3 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vue3)
- [ ] 自测 vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vite-ts)
- [ ] 自测 taro 脚手架使用小程序 & h5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/taro)