### PR TITLE
移除`*`选择器

### DIFF
--- a/src/packages/styles/mixins/index.scss
+++ b/src/packages/styles/mixins/index.scss
@@ -1,6 +1,2 @@
-* {
-  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
-  -webkit-tap-highlight-color: transparent;
-}
 @import 'make-animation.scss';
 @import 'text-ellipsis.scss';


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://nutui.jd.com/#/contributing
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
- 移除`*`的CSS选择器


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] NutUI 2.0
- [ ] NutUI 3.0 H5
- [x] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [ ] 自测 vue3 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vue3)
- [ ] 自测 vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vite-ts)
- [x] 自测 taro 脚手架使用小程序

**未修复版本主要错误信息**
因为小程序不支持`*`选择器，故此PR修改的区域会导致小程序报出以下错误：
```
[ WXSS 文件编译错误] ./app.wxss
 unexpected token "*"
  606 | }
  607 | 
> 608 | * {
      | ^
  609 |   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
  610 |   -webkit-tap-highlight-color: transparent;
  611 | }
at files://app.wxss#608(env: Windows,mp,1.05.2106300; lib: 2.20.0)
```
进而导致全局样式无效