### PR TITLE
优化关于`textarea`组件绑定值为`null`时的`length`引用错误

### DIFF
--- a/src/packages/__VUE/textarea/index.taro.vue
+++ b/src/packages/__VUE/textarea/index.taro.vue
@@ -18,7 +18,7 @@
       :placeholder="placeholder"
     />
     <view class="nut-textarea__limit" v-if="limitShow">
-      {{ modelValue.length }}/{{ maxLength }}</view
+      {{ modelValue ? modelValue.length : 0 }}/{{ maxLength }}</view
     >
   </view>
 </template>

--- a/src/packages/__VUE/textarea/index.vue
+++ b/src/packages/__VUE/textarea/index.vue
@@ -14,7 +14,7 @@
       :placeholder="placeholder"
     />
     <view class="nut-textarea__limit" v-if="limitShow">
-      {{ modelValue.length }}/{{ maxLength }}</view
+      {{ modelValue ? modelValue.length : 0 }}/{{ maxLength }}</view
     >
   </view>
 </template>


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://nutui.jd.com/#/contributing
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

优化关于`textarea`组件绑定值为`null`时的`length`引用错误

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] NutUI 2.0
- [x] NutUI 3.0 H5
- [x] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [ ] 自测 vue3 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vue3)
- [ ] 自测 vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vite-ts)
- [x] 自测 taro 脚手架使用小程序 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/taro)