### PR TITLE
feat(CellGroup): 支持title使用插槽设置

### DIFF
--- a/src/packages/__VUE/cell/doc.md
+++ b/src/packages/__VUE/cell/doc.md
@@ -124,3 +124,7 @@ export default {
 | default       | 自定义内容           |
 | link          | 自定义右侧 link 区域 |
 
+## CellGroup Slots
+| 名称          | 说明                 |
+|---------------|----------------------|
+| title `v3.1.10` | 自定义title区域 |

--- a/src/packages/__VUE/cellgroup/index.vue
+++ b/src/packages/__VUE/cellgroup/index.vue
@@ -1,6 +1,7 @@
 <template>
   <view :class="classes">
-    <view v-if="title" class="nut-cell-group__title">{{ title }}</view>
+    <slot v-if="$slots.title" name="title"></slot>
+    <view v-else-if="title" class="nut-cell-group__title">{{ title }}</view>
     <view class="nut-cell-group__warp">
       <slot></slot>
     </view>


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://nutui.jd.com/#/contributing
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

CellGroup组件支持通过插槽设置title属性，在需要给分组标题前增加一个icon中经常会用，例如：
![1504dfb2346d0f06048b29fc85dba49](https://user-images.githubusercontent.com/37258929/140251654-be718066-6d92-4f59-a731-813bd8a7ffa9.png)


**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] NutUI 2.0
- [x] NutUI 3.0 H5
- [x] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [ ] 自测 vue3 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vue3)
- [ ] 自测 vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vite-ts)
- [x] 自测 taro 脚手架使用小程序 & h5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/taro)