### PR TITLE
fix [bug]signature组件在“微信小程序”中点确认后保存的图片无法打开查看签名图片 #829

### DIFF
--- a/src/packages/__VUE/signature/index.taro.vue
+++ b/src/packages/__VUE/signature/index.taro.vue
@@ -107,15 +107,23 @@ export default create({
       if (!state.canvas) {
         return;
       }
-      Taro.canvasToTempFilePath({
-        canvas: state.canvas,
-        fileType: props.type
-      })
-        .then((res) => {
-          emit('confirm', res.tempFilePath);
+      Taro.createSelectorQuery()
+        .select("#spcanvas")
+        .fields({
+          node: true,
+          size: true,
         })
-        .catch((e) => {
-          emit('confirm', e);
+        .exec(async (res) => {
+          Taro.canvasToTempFilePath({
+            canvas: res[0].node,
+            fileType: props.type,
+          })
+            .then((res) => {
+              emit("confirm", res.tempFilePath);
+            })
+            .catch((e) => {
+              emit("confirm", e);
+            });
         });
     };
 


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://nutui.jd.com/#/contributing
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)



**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] NutUI 2.0
- [ ] NutUI 3.0 H5
- [ ] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [ ] 自测 vue3 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vue3)
- [ ] 自测 vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vite-ts)
- [ ] 自测 taro 脚手架使用小程序 & h5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/taro)