### PR TITLE
fix(tabs):当父组件默认值传入时无法更新tabs当前标签状态

### DIFF
--- a/src/packages/__VUE/tabs/index.taro.vue
+++ b/src/packages/__VUE/tabs/index.taro.vue
@@ -132,7 +132,8 @@ export default create({
         } else {
           currentIndex.value = index;
         }
-      }
+      },
+      { immediate: true }
     );
     onMounted(init);
     onActivated(init);

--- a/src/packages/__VUE/tabs/index.vue
+++ b/src/packages/__VUE/tabs/index.vue
@@ -128,7 +128,8 @@ export default create({
         } else {
           currentIndex.value = index;
         }
-      }
+      },
+      { immediate: true }
     );
     onMounted(init);
     onActivated(init);


### PR DESCRIPTION
因为watch默认惰性的一开始不会执行

<!--
请务必阅读贡献者指南:
https://nutui.jd.com/#/contributing
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
当父组件默认传入的值,tabs组件无法切换移动子组件里的item组件,因为watch是惰性,组件创始时是不会执行的
加入这个属性,可以让tabs的watch在组件初始化时执行,就可以切换tabs组件里的子组件了
```js
immediate: true
```


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] NutUI 2.0
- [x] NutUI 3.0 H5
- [x] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [ ] 自测 vue3 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vue3)
- [ ] 自测 vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vite-ts)
- [x] 自测 taro 脚手架使用小程序 & h5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/taro)