### PR TITLE
fix(countdown): countdown restTime didn't pass 2s to 1s (#877)

### DIFF
--- a/src/packages/__VUE/countdown/index.taro.vue
+++ b/src/packages/__VUE/countdown/index.taro.vue
@@ -169,8 +169,10 @@ export default create({
           let restTime = end - (Date.now() - state.p + diffTime);
           state.restTime = restTime;
           if (restTime < delay) {
-            state.restTime = 0;
-            emit('on-end');
+            setTimeout(() => {
+              state.restTime = 0;
+              emit('on-end');
+            }, restTime);
             clearInterval(state.timer as any);
           }
         } else {

--- a/src/packages/__VUE/countdown/index.vue
+++ b/src/packages/__VUE/countdown/index.vue
@@ -169,8 +169,10 @@ export default create({
           let restTime = end - (Date.now() - state.p + diffTime);
           state.restTime = restTime;
           if (restTime < delay) {
-            state.restTime = 0;
-            emit('on-end');
+            setTimeout(() => {
+              state.restTime = 0;
+              emit('on-end');
+            }, restTime);
             clearInterval(state.timer as any);
           }
         } else {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://nutui.jd.com/#/contributing
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

修复countdown组件倒计时剩余时间从2s直接跳至0s  #877 


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] NutUI 2.0
- [x] NutUI 3.0 H5
- [x] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [x] 自测 vue3 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vue3)
- [ ] 自测 vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vite-ts)
- [ ] 自测 taro 脚手架使用小程序 & h5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/taro)