### PR TITLE
npmrc里的源是npm官方源，作为国内程序员用官方源的很少了，关键是下载不了依赖，我在这卡了二十分钟，一动不动，有两个修改方案，一rc里…

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-registry=https://registry.npmjs.org
-engine-strict=true


### PR DESCRIPTION
npmrc里的源是npm官方源，作为国内程序员用官方源的很少了，关键是下载不了依赖，我在这卡了二十分钟，一动不动，有两个修改方案，一修改rc源，二删除rc文件，用开发人员电脑上默认的npm源配置