### PR TITLE
feat(input): 输入数字时拉起数字键盘

### DIFF
--- a/src/packages/__VUE/input/index.vue
+++ b/src/packages/__VUE/input/index.vue
@@ -12,6 +12,7 @@
       :disabled="disabled"
       :readonly="readonly"
       :value="modelValue"
+      :inputmode="inputmode"
       @input="valueChange"
       @focus="valueFocus"
       @blur="valueBlur"
@@ -99,6 +100,10 @@ export default create({
       };
     });
 
+    const inputmode = computed(() => {
+      return props.type === 'digit' ? 'decimal' : props.type === 'number' ? 'numeric' : 'text';
+    });
+
     const styles = computed(() => {
       return {
         textAlign: props.textAlign
@@ -152,6 +157,7 @@ export default create({
       active,
       classes,
       styles,
+      inputmode,
       valueChange,
       valueFocus,
       valueBlur,


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://nutui.jd.com/#/contributing
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
使用 `inputmode` H5 的 input 当输入数字时拉起数字键盘

MDN [link](https://developer.mozilla.org/zh-CN/docs/Web/HTML/Global_attributes/inputmode)

小程序会拉起微信的键盘，不需要使用`inputmode`属性


**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] NutUI 2.0
- [x] NutUI 3.0 H5
- [ ] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [ ] 自测 vue3 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vue3)
- [ ] 自测 vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vite-ts)
- [ ] 自测 taro 脚手架使用小程序 & h5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/taro)