### PR TITLE
fix: 滚动加载组件，taro版，下拉刷新bug修改

### DIFF
--- a/src/packages/__VUE/infiniteloading/index.taro.vue
+++ b/src/packages/__VUE/infiniteloading/index.taro.vue
@@ -50,6 +50,10 @@ export default create({
       type: Number,
       default: 200
     },
+    upperThreshold: {
+      type: Number,
+      default: 40
+    },
     pullIcon: {
       type: String,
       default: 'https://img10.360buyimg.com/imagetools/jfs/t1/169863/6/4565/6306/60125948E7e92774e/40b3a0cf42852bcb.png'
@@ -171,11 +175,6 @@ export default create({
       if (state.scrollTop == 0 && !state.isTouching && props.isOpenRefresh) {
         state.y = event.touches[0].pageY;
         state.isTouching = true;
-        getParentElement('refreshTop')
-          .boundingClientRect((rect) => {
-            state.refreshMaxH = Math.floor(rect.height * 1 + 10);
-          })
-          .exec();
       }
     };
 
@@ -205,6 +204,7 @@ export default create({
     };
 
     onMounted(() => {
+      state.refreshMaxH = props.upperThreshold;
       setTimeout(() => {
         getScrollHeight();
       }, 200);


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)
滚动加载组件，taro版，下拉刷新功能BUG，没有下拉距离，导致点击事件也会加载列表。
BUG原因，下拉距离想通过下拉加载动画的DOM高度去计算，但是小程序的获取dom是异步的，导致高度没有获取到，从而造成该BUG。
修改内容： 参考小程序scrollview组件，增加一个props 为upperThreshold，作为下拉加载的阈值，触发加载请求。

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] NutUI 2.0
- [ ] NutUI 3.0 H5
- [x] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [ ] 自测 vue3 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vue3)
- [ ] 自测 vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vite-ts)
- [x] 自测 taro 脚手架使用小程序 & h5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/taro)