### PR TITLE
fix: 修复日期选择器modelValue不能双向数据绑定的BUG

### DIFF
--- a/src/packages/__VUE/datepicker/index.taro.vue
+++ b/src/packages/__VUE/datepicker/index.taro.vue
@@ -275,6 +275,13 @@ export default create({
     });
 
     watch(
+      () => props.modelValue,
+      (value) => {
+        state.currentDate = formatValue(value);
+      }
+    );
+
+    watch(
       () => props.title,
       (val) => {
         state.title = val;

--- a/src/packages/__VUE/datepicker/index.vue
+++ b/src/packages/__VUE/datepicker/index.vue
@@ -274,6 +274,13 @@ export default create({
     });
 
     watch(
+      () => props.modelValue,
+      (value) => {
+        state.currentDate = formatValue(value);
+      }
+    );
+
+    watch(
       () => props.title,
       (val) => {
         state.title = val;


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://nutui.jd.com/#/contributing
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

对于时间日期选择器modelValue只在mounted里赋值，没有进一步监听，导致后期外部修改值无法更改组件中的值，有违双向数据绑定原理，特此修改。设计组件： datepicker/index.vue   datepicker/index.taro.vue

**这个 PR 是什么类型?** (至少选择一个)

- [X] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] NutUI 2.0
- [X] NutUI 3.0 H5
- [X] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [ ] 自测 vue3 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vue3)
- [ ] 自测 vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vite-ts)
- [X] 自测 taro 脚手架使用小程序 & h5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/taro)