### PR TITLE
feat(progress): 新增text-inside-background属性,用以设置内显文本的背景色(#1142)

### DIFF
--- a/src/packages/__VUE/progress/index.taro.vue
+++ b/src/packages/__VUE/progress/index.taro.vue
@@ -12,7 +12,12 @@
           class="nut-progress-text nut-progress-insidetext"
           ref="insideText"
           :id="'nut-progress-insidetext-taro-' + randRef"
-          :style="{ lineHeight: height, left: `${percentage}%`, transform: `translate(-${+percentage}%,-50%)` }"
+          :style="{
+            lineHeight: height,
+            left: `${percentage}%`,
+            transform: `translate(-${+percentage}%,-50%)`,
+            background: bgStyle.textInsideBackground || bgStyle.background || ''
+          }"
           v-if="showText && textInside"
         >
           <span :style="textStyle">{{ percentage }}{{ isShowPercentage ? '%' : '' }}</span>
@@ -59,6 +64,10 @@ export default create({
       type: Boolean,
       default: false
     },
+    textInsideBackground: {
+      type: String,
+      default: ''
+    },
     showText: {
       type: Boolean,
       default: true
@@ -93,7 +102,8 @@ export default create({
     const bgStyle = computed(() => {
       return {
         width: props.percentage + '%',
-        background: props.strokeColor || ''
+        background: props.strokeColor || '',
+        textInsideBackground: props.textInsideBackground || props.strokeColor || ''
       };
     });
     const textStyle = computed(() => {

--- a/src/packages/__VUE/progress/index.vue
+++ b/src/packages/__VUE/progress/index.vue
@@ -10,7 +10,12 @@
         <div
           class="nut-progress-text nut-progress-insidetext"
           ref="insideText"
-          :style="{ lineHeight: height, left: `${percentage}%`, transform: `translate(-${+percentage}%,-50%)` }"
+          :style="{
+            lineHeight: height,
+            left: `${percentage}%`,
+            transform: `translate(-${+percentage}%,-50%)`,
+            background: bgStyle.textInsideBackground || bgStyle.background || ''
+          }"
           v-if="showText && textInside"
         >
           <span :style="textStyle">{{ percentage }}{{ isShowPercentage ? '%' : '' }} </span>
@@ -56,6 +61,10 @@ export default create({
       type: Boolean,
       default: false
     },
+    textInsideBackground: {
+      type: String,
+      default: ''
+    },
     showText: {
       type: Boolean,
       default: true
@@ -88,7 +97,8 @@ export default create({
     const bgStyle = computed(() => {
       return {
         width: props.percentage + '%',
-        background: props.strokeColor || ''
+        background: props.strokeColor || '',
+        textInsideBackground: props.textInsideBackground || props.strokeColor || ''
       };
     });
     const textStyle = computed(() => {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://nutui.jd.com/#/contributing
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)  

 新增text-inside-background属性,用以设置内显文本的背景色(#1142)  

![1648058208(1)](https://user-images.githubusercontent.com/42437658/159768227-88347817-5458-4da5-8133-5b3440338740.jpg)

设置背景色👇
text-inside-background="green"
---

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] NutUI 2.0
- [x] NutUI 3.0 H5
- [x] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [x] 自测 vue3 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vue3)
- [ ] 自测 vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vite-ts)
- [x] 自测 taro 脚手架使用小程序 & h5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/taro)