### PR TITLE
Update index.vue

### DIFF
--- a/src/packages/__VUE/input/index.vue
+++ b/src/packages/__VUE/input/index.vue
@@ -192,6 +192,10 @@ export default create({
       type: [String, Number],
       default: ''
     },
+    maxlength: {
+      type: [String, Number],
+      default: ''
+    },
     leftIcon: {
       type: String,
       default: ''


### PR DESCRIPTION
Property "maxLength" was accessed during render but is not defined on instance.

<!--
请务必阅读贡献者指南:
https://nutui.jd.com/#/contributing
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

maxLength 居然是未定义的。

**这个 PR 是什么类型?** (至少选择一个)

- 错误修复(Bugfix) issue id #

**这个 PR 涉及以下平台:**


- [ ] NutUI 3.0 H5
- [ ] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [ ] 自测 vue3 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vue3)