### PR TITLE
input组件 在textarea类型下报错 maxLength未定义

### DIFF
--- a/src/packages/__VUE/input/index.vue
+++ b/src/packages/__VUE/input/index.vue
@@ -192,6 +192,10 @@ export default create({
       type: [String, Number],
       default: ''
     },
+    maxLength: {
+      type: [String, Number],
+      default: ''
+    },
     leftIcon: {
       type: String,
       default: ''


### PR DESCRIPTION
在textarea类型下报错 maxLength未定义，需要增加 maxLength props
    maxLength: {
      type: [String, Number],
      default: ''
    },

- [ ] 错误修复(Bugfix) issue id

- [ ] NutUI 3.0 H5
- [ ] NutUI 3.0 小程序
**这个 PR 是否已自测:**
- [ ] 自测 vue3 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vue3)
