### PR TITLE
fix(formitem): class and style cannot be set on the formitem

### DIFF
--- a/src/packages/__VUE/formitem/index.vue
+++ b/src/packages/__VUE/formitem/index.vue
@@ -1,5 +1,9 @@
 <template>
-  <nut-cell class="nut-form-item" :class="{ error: parent[prop], line: showErrorLine }">
+  <nut-cell
+    class="nut-form-item"
+    :class="[{ error: parent[prop], line: showErrorLine }, $attrs.class]"
+    :style="$attrs.style"
+  >
     <view class="nut-cell__title nut-form-item__label" :style="labelStyle" v-if="label" :class="{ required: required }">
       {{ label }}</view
     >


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://nutui.jd.com/#/contributing
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

修复了无法给formitem组件添加class及style的问题，因为设置inheritAttrs为false后无法自动继承class及style。

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] NutUI 2.0
- [x] NutUI 3.0 H5
- [x] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [x] 自测 vue3 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vue3)
- [x] 自测 vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vite-ts)
- [x] 自测 taro 脚手架使用小程序 & h5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/taro)