### PR TITLE
fix(elevator): navbar not working in taro h5

### DIFF
--- a/src/packages/__VUE/elevator/index.taro.vue
+++ b/src/packages/__VUE/elevator/index.taro.vue
@@ -184,7 +184,7 @@ export default create({
 
     onMounted(() => {
       if (Taro.getEnv() === 'WEB') {
-        calculateHeight();
+        nextTick(calculateHeight);
       } else {
         eventCenter.once((getCurrentInstance() as any).router.onReady, () => {
           calculateHeight();


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://nutui.jd.com/#/contributing
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

修复了taro h5环境下elevator右侧导航栏无效的问题，错误原因如下：
在nextTick之后收集listGroup导致calculateHeight时listGroup为空，从而导致右侧导航栏失效。
![image](https://user-images.githubusercontent.com/17243584/161378431-7521911f-e8ef-41a9-b8ff-53038b1d874d.png)

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] NutUI 2.0
- [ ] NutUI 3.0 H5
- [x] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [x] 自测 vue3 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vue3)
- [x] 自测 vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vite-ts)
- [x] 自测 taro 脚手架使用小程序 & h5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/taro)