### PR TITLE
feat: 单选框和复选框支持外部自定义图标

### DIFF
--- a/src/packages/__VUE/checkbox/doc.md
+++ b/src/packages/__VUE/checkbox/doc.md
@@ -248,6 +248,8 @@ app.use(Checkbox).use(CheckboxGroup).use(Icon);
 | icon-size | [图标尺寸](#/icon) | String、Number | `18`
 | icon-name | [图标名称](#/icon)，选中前(建议和`icon-active-name`一起修改) | String | `'check-normal'`
 | icon-active-name | [图标名称](#/icon)，选中后(建议和`icon-name`一起修改) | String | `'checked'`
+| icon-class-prefix | 自定义 icon 类名前缀，用于使用自定义图标        | String                  | `nut-icon` |
+| icon-font-class-name | 自定义 icon 字体基础类名        | String                  | `nutui-iconfont` |
 | label | 复选框的文本内容 | String | -
 
 

--- a/src/packages/__VUE/checkbox/index.taro.vue
+++ b/src/packages/__VUE/checkbox/index.taro.vue
@@ -35,6 +35,14 @@ export default create({
     label: {
       type: String,
       default: ''
+    },
+    iconClassPrefix: {
+      type: String,
+      default: 'nut-icon'
+    },
+    iconFontClassName: {
+      type: String,
+      default: 'nutui-iconfont'
     }
   },
   emits: ['change', 'update:modelValue'],
@@ -71,11 +79,13 @@ export default create({
     };
 
     const renderIcon = () => {
-      const { iconName, iconSize, iconActiveName } = props;
+      const { iconName, iconSize, iconActiveName, iconClassPrefix, iconFontClassName } = props;
       return h(nutIcon, {
         name: !pValue.value ? iconName : iconActiveName,
         size: iconSize,
-        class: color.value
+        class: color.value,
+        classPrefix: iconClassPrefix,
+        fontClassName: iconFontClassName
       });
     };
 

--- a/src/packages/__VUE/checkbox/index.vue
+++ b/src/packages/__VUE/checkbox/index.vue
@@ -36,6 +36,14 @@ export default create({
     label: {
       type: String,
       default: ''
+    },
+    iconClassPrefix: {
+      type: String,
+      default: 'nut-icon'
+    },
+    iconFontClassName: {
+      type: String,
+      default: 'nutui-iconfont'
     }
   },
   emits: ['change', 'update:modelValue'],
@@ -72,11 +80,13 @@ export default create({
     };
 
     const renderIcon = () => {
-      const { iconName, iconSize, iconActiveName } = props;
+      const { iconName, iconSize, iconActiveName, iconClassPrefix, iconFontClassName } = props;
       return h(nutIcon, {
         name: !pValue.value ? iconName : iconActiveName,
         size: iconSize,
-        class: color.value
+        class: color.value,
+        classPrefix: iconClassPrefix,
+        fontClassName: iconFontClassName
       });
     };
 

--- a/src/packages/__VUE/radio/doc.md
+++ b/src/packages/__VUE/radio/doc.md
@@ -207,6 +207,8 @@ app.use(Radio).use(RadioGroup);
 | icon-size        | [图标尺寸](#/icon)                                           | String、Number          | `18`              |
 | icon-name        | [图标名称](#/icon)，选中前(建议和`icon-active-name`一起修改) | String                  | `'check-normal'`  |
 | icon-active-name | [图标名称](#/icon)，选中后(建议和`icon-name`一起修改)        | String                  | `'check-checked'` |
+| icon-class-prefix | 自定义 icon 类名前缀，用于使用自定义图标        | String                  | `nut-icon` |
+| icon-font-class-name | 自定义 icon 字体基础类名        | String                  | `nutui-iconfont` |
 | label            | 单选框标识                                                   | String、Number、Boolean | -                 |
 | shape            | 形状，可选值为 button、round                                 | String                  | round             |
 

--- a/src/packages/__VUE/radio/index.taro.vue
+++ b/src/packages/__VUE/radio/index.taro.vue
@@ -29,6 +29,14 @@ export default create({
     iconSize: {
       type: [String, Number],
       default: ''
+    },
+    iconClassPrefix: {
+      type: String,
+      default: 'nut-icon'
+    },
+    iconFontClassName: {
+      type: String,
+      default: 'nutui-iconfont'
     }
   },
   setup(props, { emit, slots }) {
@@ -51,11 +59,13 @@ export default create({
     });
 
     const renderIcon = () => {
-      const { iconName, iconSize, iconActiveName } = props;
+      const { iconName, iconSize, iconActiveName, iconClassPrefix, iconFontClassName } = props;
       return h(nutIcon, {
         name: isCurValue.value ? iconActiveName : iconName,
         size: iconSize,
-        class: color.value
+        class: color.value,
+        classPrefix: iconClassPrefix,
+        fontClassName: iconFontClassName
       });
     };
 

--- a/src/packages/__VUE/radio/index.vue
+++ b/src/packages/__VUE/radio/index.vue
@@ -29,6 +29,14 @@ export default create({
     iconSize: {
       type: [String, Number],
       default: ''
+    },
+    iconClassPrefix: {
+      type: String,
+      default: 'nut-icon'
+    },
+    iconFontClassName: {
+      type: String,
+      default: 'nutui-iconfont'
     }
   },
   setup(props, { emit, slots }) {
@@ -51,11 +59,13 @@ export default create({
     });
 
     const renderIcon = () => {
-      const { iconName, iconSize, iconActiveName } = props;
+      const { iconName, iconSize, iconActiveName, iconClassPrefix, iconFontClassName } = props;
       return h(nutIcon, {
         name: isCurValue.value ? iconActiveName : iconName,
         size: iconSize,
-        class: color.value
+        class: color.value,
+        classPrefix: iconClassPrefix,
+        fontClassName: iconFontClassName
       });
     };
 


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://nutui.jd.com/#/contributing
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

使单选框和复选框支持**外部**自定义图标

单选框和复选框新增两个属性：
| 字段 | 说明 | 类型 | 默认值
|----- | ----- | ----- | ----- 
| icon-class-prefix | 自定义 icon 类名前缀，用于使用自定义图标        | String                  | `nut-icon` |
| icon-font-class-name | 自定义 icon 字体基础类名        | String                  | `nutui-iconfont` |


**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] NutUI 2.0
- [x] NutUI 3.0 H5
- [x] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [ ] 自测 vue3 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vue3)
- [ ] 自测 vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vite-ts)
- [ ] 自测 taro 脚手架使用小程序 & h5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/taro)