### PR TITLE
fix: input show-word-limit 默认 false

### DIFF
--- a/src/packages/__VUE/input/index.taro.vue
+++ b/src/packages/__VUE/input/index.taro.vue
@@ -250,7 +250,7 @@ export default create({
     },
     showWordLimit: {
       type: Boolean,
-      default: true
+      default: false
     },
     autofocus: {
       type: Boolean,

--- a/src/packages/__VUE/input/index.vue
+++ b/src/packages/__VUE/input/index.vue
@@ -250,7 +250,7 @@ export default create({
     },
     showWordLimit: {
       type: Boolean,
-      default: true
+      default: false
     },
     autofocus: {
       type: Boolean,


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)
修改input的show-word-limit默认为false，与官方文档、之前版本一致。
之前版本默认为false（官方文档默认为false）。
如果之前设置了maxLength并升级了这个版本，可能会意外出现这个字数提示，引起ui异常，如下图所示。
问题表现：升级后
![image](https://user-images.githubusercontent.com/4652410/163357283-a0482a83-c07a-40e2-9592-a8463a88a55d.png)
升级前
![image](https://user-images.githubusercontent.com/4652410/163357162-3dd19a4c-342a-40aa-bb97-94ba7df1d8bd.png)

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] NutUI 2.0
- [x] NutUI 3.0 H5
- [x] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [x] 自测 vue3 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vue3)
- [ ] 自测 vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vite-ts)
- [ ] 自测 taro 脚手架使用小程序 & h5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/taro)