### PR TITLE
table支持自定义表头icon、支持render入参等

### DIFF
--- a/src/packages/__VUE/table/demo.vue
+++ b/src/packages/__VUE/table/demo.vue
@@ -254,8 +254,7 @@ export default createDemo({
       timer: null as number | null,
       summary: () => {
         return {
-          value: '这是总结栏',
-          colspan: 5
+          value: '这是总结栏'
         };
       }
     });

--- a/src/packages/__VUE/table/demo.vue
+++ b/src/packages/__VUE/table/demo.vue
@@ -188,7 +188,8 @@ export default createDemo({
           name: 'Tom',
           sex: '男',
           record: '小学',
-          render: () => {
+          render: (data) => {
+            console.log(data);
             return h(
               Button,
               {

--- a/src/packages/__VUE/table/demo.vue
+++ b/src/packages/__VUE/table/demo.vue
@@ -104,7 +104,10 @@ export default createDemo({
         {
           title: '姓名',
           key: 'name',
-          align: 'center'
+          align: 'center',
+          render(data) {
+            return `${data.name}(${data.sex})`;
+          }
         },
         {
           title: '性别',

--- a/src/packages/__VUE/table/demo.vue
+++ b/src/packages/__VUE/table/demo.vue
@@ -22,6 +22,12 @@
     <nut-table :columns="columns3" :data="data5"> </nut-table>
     <h2>支持排序</h2>
     <nut-table :columns="columns6" :data="data6" @sorter="handleSorter"> </nut-table>
+    <h2>支持自定义表头icon</h2>
+    <nut-table :columns="columns1" :data="data1">
+      <template #icon-name>
+        <nut-icon name="people"></nut-icon>
+      </template>
+    </nut-table>
   </div>
 </template>
 

--- a/src/packages/__VUE/table/index.vue
+++ b/src/packages/__VUE/table/index.vue
@@ -31,6 +31,11 @@
           >
             {{ typeof item[value] !== 'function' ? item[value] : '' }}
             <RenderColumn :slots="item[value]" :data="item" v-if="typeof item[value] === 'function'"></RenderColumn>
+            <RenderColumn
+              :slots="getColumnItem(value).render"
+              :data="item"
+              v-else-if="typeof getColumnItem(value).render === 'function'"
+            ></RenderColumn>
           </span>
         </view>
       </view>

--- a/src/packages/__VUE/table/index.vue
+++ b/src/packages/__VUE/table/index.vue
@@ -12,7 +12,12 @@
           >
             {{ item.title }}
             <slot name="icon"></slot>
-            <nut-icon v-if="!$slots.icon && item.sorter" name="down-arrow" size="12px"></nut-icon>
+            <slot :name="`icon-${item.key}`"></slot>
+            <nut-icon
+              v-if="!$slots.icon && !$slots[`icon-${item.key}`] && item.sorter"
+              name="down-arrow"
+              size="12px"
+            ></nut-icon>
           </span>
         </view>
       </view>

--- a/src/packages/__VUE/table/index.vue
+++ b/src/packages/__VUE/table/index.vue
@@ -30,7 +30,7 @@
             :key="value"
           >
             {{ typeof item[value] !== 'function' ? item[value] : '' }}
-            <RenderColumn :slots="item[value]" v-if="typeof item[value] === 'function'"></RenderColumn>
+            <RenderColumn :slots="item[value]" :data="item" v-if="typeof item[value] === 'function'"></RenderColumn>
           </span>
         </view>
       </view>

--- a/src/packages/__VUE/table/renderColumn.ts
+++ b/src/packages/__VUE/table/renderColumn.ts
@@ -1,9 +1,10 @@
 import { h } from 'vue';
 export default {
   setup(props: any) {
-    return () => h(`view`, {}, props.slots());
+    return () => h(`view`, {}, props.slots(props.data));
   },
   props: {
-    slots: Object
+    slots: Object,
+    data: Object
   }
 };


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://nutui.jd.com/#/contributing
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
table支持自定义表头icon、支持render入参、column支持render(优先级：行数据render>column render)


**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [x] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] NutUI 2.0
- [x] NutUI 3.0 H5
- [x] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [x] 自测 vue3 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vue3)
- [x] 自测 vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vite-ts)
- [x] 自测 taro 脚手架使用小程序 & h5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/taro)