### PR TITLE
fix: 修复BackTop demo页面按钮被遮挡样式问题

### DIFF
--- a/src/packages/__VUE/backtop/demo.vue
+++ b/src/packages/__VUE/backtop/demo.vue
@@ -25,12 +25,12 @@
     <div class="text-data">我是测试数据22</div>
     <div class="text-data">我是测试数据23</div>
     <div class="text-data">我是测试数据24</div>
-    <nut-backtop @click="handleClick" el-id="elId" :distance="100" :bottom="90">
-      <view class="backtop-demo"
-        ><nut-icon size="12px" class="nut-backtop-main" name="top"></nut-icon><view class="title">顶部</view></view
-      >
+    <nut-backtop @click="handleClick" el-id="elId" :distance="100" :bottom="110">
+      <view class="backtop-demo">
+        <nut-icon size="12px" class="nut-backtop-main" name="top"></nut-icon><view class="title">顶部</view>
+      </view>
     </nut-backtop>
-    <nut-backtop @click="handleClick" el-id="elId" :distance="200"></nut-backtop>
+    <nut-backtop @click="handleClick" el-id="elId" :distance="200" :bottom="50"></nut-backtop>
   </div>
 </template>
 


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://nutui.jd.com/#/contributing
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
修复BackTop demo页面按钮被遮挡样式问题


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] NutUI 2.0
- [ ] NutUI 3.0 H5
- [ ] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [x] 自测 vue3 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vue3)
- [ ] 自测 vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vite-ts)
- [ ] 自测 taro 脚手架使用小程序 & h5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/taro)