### PR TITLE
fix: popup-taro版本，自定义内容无法获取100%高度问题修复

### DIFF
--- a/src/packages/__VUE/popup/index.scss
+++ b/src/packages/__VUE/popup/index.scss
@@ -87,6 +87,9 @@
   background-color: $white;
   transition: transform 0.2s;
   -webkit-overflow-scrolling: touch;
+  .nutui-popup__content-wrapper {
+    height: 100%;
+  }
 }
 
 .nut-overflow-hidden {

--- a/src/packages/__VUE/popup/index.taro.vue
+++ b/src/packages/__VUE/popup/index.taro.vue
@@ -13,7 +13,7 @@
     />
     <Transition :name="transitionName" @after-enter="onOpened" @after-leave="onClosed">
       <view v-show="visible" :class="classes" :style="popStyle" @click="onClick">
-        <div v-show="showSlot"><slot></slot></div>
+        <div class="nutui-popup__content-wrapper" v-show="showSlot"><slot></slot></div>
         <view
           v-if="closed"
           @click="onClickCloseIcon"


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://nutui.jd.com/#/contributing
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
popup-taro版本，自定义内容无法获取100%高度问题修复

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] NutUI 2.0
- [ ] NutUI 3.0 H5
- [x] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [ ] 自测 vue3 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vue3)
- [ ] 自测 vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vite-ts)
- [ ] 自测 taro 脚手架使用小程序 & h5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/taro)