### PR TITLE
style: fix font family of highlighted code

### DIFF
--- a/src/sites/assets/styles/highlight.scss
+++ b/src/sites/assets/styles/highlight.scss
@@ -13,6 +13,10 @@ code {
   -webkit-font-smoothing: auto;
   background-color: #fafafa;
   border-radius: 16px;
+
+  span {
+    font-family: $nutui-doc-code-font-family;
+  }
 }
 
 pre {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://nutui.jd.com/#/contributing
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

使代码块使用等宽字体。

修改前：

![Snipaste_2022-06-06_18-07-04](https://user-images.githubusercontent.com/47095648/172140770-447b27e5-bdab-41b6-afdc-c01bb8bccb29.png)

修改后：

![Snipaste_2022-06-06_18-06-50](https://user-images.githubusercontent.com/47095648/172140736-27876422-47d0-4aa2-a9c9-818560c5ca66.png)

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [x] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] NutUI 2.0
- [ ] NutUI 3.0 H5
- [ ] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [ ] 自测 vue3 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vue3)
- [ ] 自测 vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vite-ts)
- [ ] 自测 taro 脚手架使用小程序 & h5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/taro)