### PR TITLE
docs: lock-scroll attribute of overlay should be true

### DIFF
--- a/src/packages/__VUE/overlay/doc.en-US.md
+++ b/src/packages/__VUE/overlay/doc.en-US.md
@@ -135,7 +135,7 @@ It can be set through `overlay-style`
 | duration               | Animation duration, Unit second | String, Number | `0.3`    |
 | overlay-class          | Custom mask classname   | String         | -      |
 | overlay-style          | Custom mask styles   | CSSProperties  | -      |
-| lock-scroll            | Whether the background is locked(`MiniProgram not supported`)     | Boolean        | `false`  |
+| lock-scroll            | Whether the background is locked(`MiniProgram not supported`)     | Boolean        | `true`  |
 | close-on-click-overlay | Click to close the mask | Boolean        | `true`   |
 
 ### Events

--- a/src/packages/__VUE/overlay/doc.md
+++ b/src/packages/__VUE/overlay/doc.md
@@ -134,7 +134,7 @@ app.use(OverLay);
 | duration               | 动画时长，单位秒 | String, Number | `0.3`    |
 | overlay-class          | 自定义遮罩类名   | String         | -      |
 | overlay-style          | 自定义遮罩样式   | CSSProperties  | -      |
-| lock-scroll            | 背景是否锁定(`小程序不支持`)     | Boolean        | `false`  |
+| lock-scroll            | 背景是否锁定(`小程序不支持`)     | Boolean        | `true`  |
 | close-on-click-overlay | 是否点击遮罩关闭 | Boolean        | `true`   |
 
 ### Events


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://nutui.jd.com/#/contributing
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
将文档中 overlay 组件的 lock-scroll  默认属性值更新为 true
修改依据: https://github.com/jdf2e/nutui/blob/next/src/packages/__VUE/overlay/index.vue#L39

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [x] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] NutUI 2.0
- [ ] NutUI 3.0 H5
- [ ] NutUI 3.0 小程序

