### PR TITLE
chore: use `cz-git` commitizen adapter

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 /src/packages/**/*.md
+commitlint.config.js

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,3 +1,22 @@
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const components = fs
+  .readdirSync(path.resolve(__dirname, './src/packages/__VUE'), { withFileTypes: true })
+  .filter((dirent) => dirent.isDirectory())
+  .map((dirent) => dirent.name);
+
+// precomputed scope
+const scopeComplete = execSync('git status --porcelain || true')
+  .toString()
+  .trim()
+  .split('\n')
+  .find((r) => r.indexOf('M  ') !== -1)
+  ?.replace(/(\/)/g, '%%')
+  ?.match(/src%%packages%%__VUE%%((\w|-)*)/)?.[1];
+
+/** @type {import('cz-git').UserConfig} */
 module.exports = {
   extends: ['@commitlint/config-conventional'],
   rules: {
@@ -5,11 +24,7 @@ module.exports = {
     'footer-leading-blank': [1, 'always'],
     'header-max-length': [2, 'always', 72],
     'scope-case': [2, 'always', 'lower-case'],
-    'subject-case': [
-      2,
-      'never',
-      ['sentence-case', 'start-case', 'pascal-case', 'upper-case']
-    ],
+    'subject-case': [2, 'never', ['sentence-case', 'start-case', 'pascal-case', 'upper-case']],
     'subject-empty': [2, 'never'],
     'subject-full-stop': [2, 'never', '.'],
     'type-case': [2, 'always', 'lower-case'],
@@ -17,18 +32,15 @@ module.exports = {
     'type-enum': [
       2,
       'always',
-      [
-        'upd',
-        'chore',
-        'docs',
-        'feat',
-        'fix',
-        'test',
-        'refactor',
-        'revert',
-        'style',
-        'release'
-      ]
+      ['upd', 'chore', 'docs', 'feat', 'fix', 'test', 'refactor', 'revert', 'style', 'release']
     ]
+  },
+  prompt: {
+    typesAppend: [{ value: 'upd', name: 'upd:  ' }],
+    customScopesAlign: !scopeComplete ? 'top' : 'bottom',
+    scopes: [...components],
+    defaultScope: scopeComplete,
+    allowCustomIssuePrefixs: false,
+    allowEmptyIssuePrefixs: false
   }
 };

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "autoprefixer": "^10.3.4",
     "axios": "^0.21.0",
     "canvas": "^2.9.0",
+    "cz-git": "^1.3.8",
     "eslint": "^7.23.2",
     "eslint-plugin-prettier": "^3.3.1",
     "eslint-plugin-vue": "^7.8.0",
@@ -139,6 +140,11 @@
     "rules": {
       "vue/no-unused-components": "off",
       "no-debugger": "off"
+    }
+  },
+  "config": {
+    "commitizen": {
+      "path": "node_modules/cz-git"
     }
   },
   "lint-staged": {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://nutui.jd.com/#/contributing
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

Use `cz-git` commitizen adapter

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [x] 其他，请描述(Other, please describe):

Hi, I am the author of `cz-git` and stumbled upon this library's commit message should use the `commitizen` CLI. And use the component name as the scope. I think the `cz-git` adapter can help the maintainers of the project.
github: https://github.com/Zhengqbbb/cz-git
website | guide: https://cz-git.qbenben.com/
中文文档：https://cz-git.qbenben.com/zh/

### Demo:
![demo](https://user-images.githubusercontent.com/40693636/175833599-b00e5ddf-56b7-4e3f-99c3-23d582e08b01.gif)


### Features:
- **With Commitlint** : Dynamically get commitlint configuration and give command line prompts.
- **Friendly** : Supports search and selection on the command line, reducing spelling errors.
- **Lightweight** : zero dependency (1.5MB)

### Show,
The scope list will automatically pin the component name to top of the component name if it matches a change in the component directory.
![demo](https://user-images.githubusercontent.com/40693636/175834142-3fc82523-cc15-4eee-892e-12d077040248.gif)



### BTW
1. I don't understand the meaning of `upd` in types. please let me know as soon as possible
2. https://nutui.jd.com/#/contributing is a dead link
