### PR TITLE
Address新增自定义按钮;修复默认加载selectedExistAddress未赋值

### DIFF
--- a/src/packages/__VUE/address/demo.vue
+++ b/src/packages/__VUE/address/demo.vue
@@ -92,6 +92,27 @@
       @switch-module="switchModule"
       @close-mask="closeMask"
     ></nut-address>
+
+    <h2>{{ translate('customBtnAddress') }}</h2>
+    <nut-cell :title="translate('title')" :desc="seven" is-link @click="showAddressCustomBtn"></nut-cell>
+
+    <nut-address
+      v-model:visible="customBtn"
+      type="exist"
+      :exist-address="existAddress"
+      :province="province"
+      :city="city"
+      :country="country"
+      :town="town"
+      :back-btn-icon="backBtnIcon"
+      :is-show-custom-address="false"
+      :is-show-custom-btn-and-exist="true"
+      @change="(cal) => onChange(cal, 'customBtn')"
+      @close="close7"
+      @selected="selected"
+      @custom-switch-module="customSwitchModule"
+      @close-mask="closeMask"
+    ></nut-address>
   </div>
 </template>
 
@@ -111,7 +132,8 @@ useTranslate({
     existAddress: '选择已有地址',
     icon: '自定义图标',
     change: '自定义地址与已有地址切换',
-    textAddress: '北京朝阳区八里庄街道'
+    textAddress: '北京朝阳区八里庄街道',
+    customBtnAddress: '已有地址自定义按钮'
   },
   'en-US': {
     basic: 'Basic Usage',
@@ -122,7 +144,8 @@ useTranslate({
     existAddress: 'Choose Exist Address',
     icon: 'Custom Icon',
     change: 'Custom Or Exist',
-    textAddress: 'Balizhuang Street, Chaoyang District, Beijing'
+    textAddress: 'Balizhuang Street, Chaoyang District, Beijing',
+    customBtnAddress: 'Exist Address Custom Btn'
   }
 });
 
@@ -193,6 +216,7 @@ export default createDemo({
       exist: false,
       customImg: false,
       other: false,
+      customBtn: false,
       select: false
     });
 
@@ -245,7 +269,8 @@ export default createDemo({
       three: translate('title'),
       four: translate('title'),
       five: translate('textAddress'),
-      six: translate('textAddress')
+      six: translate('textAddress'),
+      seven: translate('title')
     });
 
     const showAddress = () => {
@@ -302,6 +327,9 @@ export default createDemo({
     const showAddressOther = () => {
       showPopup.other = true;
     };
+    const showAddressCustomBtn = () => {
+      showPopup.customBtn = true;
+    };
     const showCustomImg = () => {
       showPopup.customImg = true;
     };
@@ -315,7 +343,6 @@ export default createDemo({
         text.three = val.data.addressStr;
       }
     };
-
     const close4 = (val: CalResult) => {
       console.log(val);
       if (val.type == 'exist') {
@@ -325,13 +352,26 @@ export default createDemo({
         text.four = val.data.addressStr;
       }
     };
-
+    const close7 = (val: CalResult) => {
+      console.log(val);
+      if (val.type == 'exist') {
+        const { provinceName, cityName, countyName, townName, addressDetail } = val.data;
+        text.seven = provinceName + cityName + countyName + townName + addressDetail;
+      } else {
+        text.seven = val.data.addressStr;
+      }
+    };
     const switchModule = (val: CalResult) => {
       if (val.type == 'custom') {
         console.log('点击了“选择其他地址”按钮');
       } else {
         console.log('点击了自定义地址左上角的返回按钮');
       }
+    };
+
+    const customSwitchModule = (address: any) => {
+      console.log(address);
+      console.log('点击了自定义按钮');
     };
 
     const closeMask = (val: CalResult) => {
@@ -354,10 +394,13 @@ export default createDemo({
       showSelected,
       existAddress,
       showAddressOther,
+      showAddressCustomBtn,
       showCustomImg,
       close3,
       close4,
+      close7,
       switchModule,
+      customSwitchModule,
       closeMask,
       placeholder,
       translate,

--- a/src/packages/__VUE/address/doc.en-US.md
+++ b/src/packages/__VUE/address/doc.en-US.md
@@ -545,6 +545,8 @@ If you want to select a province, you need to set the region ID in the order of 
 | custom-address-title  | Custom address title | String | 'Select Region'
 | exist-address-title|  Exist address title | String | 'Delivery To'
 | custom-and-exist-title| Custom address and existing address switch button copywriting | String | 'Choose Another Address'
+| custom-btn-and-exist-title| Custom Btn and existing address ，type=‘exist’ | String | 'Custom Btn'
+| is-show-custom-btn-and-exist | Whether to change custom Btn，type=‘exist’  | Boolean | false
 | columns-placeholder | Columns placeholder text | String|Array | 'Select'
 | lock-scroll   | Whether the background is locked   | Boolean        | `true`       
 
@@ -557,6 +559,7 @@ If you want to select a province, you need to set the region ID in the order of 
 | close |  Emitted when to close  | reference close
 | close-mask | Emitted when to close mask | {closeWay:'mask'/'cross'}
 | switch-module | Click to select another address or custom address to select the upper left corner of the return button triggered | {type:'exist'/'custom'/'custom2'}
+| custom-switch-module | Click to Custom button event | {type:'exist'/'custom'/'custom2'}
 
 
 ## change 

--- a/src/packages/__VUE/address/doc.md
+++ b/src/packages/__VUE/address/doc.md
@@ -547,6 +547,8 @@ app.use(Elevator);
 | custom-address-title  | 自定义地址选择文案，type='custom' 时生效 | String | '请选择所在地区'
 | exist-address-title| 已有地址文案 ，type=‘exist’ 时生效| String | '配送至'
 | custom-and-exist-title| 自定义地址与已有地址切换按钮文案 ，type=‘exist’ 时生效| String | '选择其他地址'
+| custom-btn-and-exist-title| 已有地址自定义按钮文案 ，type=‘exist’ 时生效| String | '自定义按钮'
+| is-show-custom-btn-and-exist | 是否显示自定义按钮，type=‘exist’ 时生效 | Boolean | false
 | columns-placeholder | 列提示文字 | String|Array | '请选择'
 | lock-scroll  | 背景是否锁定      | Boolean        | `true`       
 
@@ -566,6 +568,7 @@ app.use(Elevator);
 | close | 地址选择弹框关闭时触发 | 参考 close
 | close-mask |点击遮罩层或点击右上角叉号关闭时触发 | {closeWay:'mask'/'cross'}
 | switch-module | 点击‘选择其他地址’或自定义地址选择左上角返回按钮触发 | {type:'exist'/'custom'/'custom2'}
+| custom-switch-module | 点击‘自定义按钮’触发 | {type:'exist'/'custom'/'custom2'}
 
 
 ## change 回调参数

--- a/src/packages/__VUE/address/index.taro.vue
+++ b/src/packages/__VUE/address/index.taro.vue
@@ -122,6 +122,9 @@
         <div class="choose-other" @click="switchModule" v-if="isShowCustomAddress">
           <div class="btn">{{ customAndExistTitle || translate('chooseAnotherAddress') }}</div>
         </div>
+        <div class="choose-other" @click="customSwitchModule" v-if="isShowCustomBtnAndExist">
+          <div class="btn">{{ customBtnAndExistTitle || translate('newCustomBtn') }}</div>
+        </div>
       </view>
     </view>
   </nut-popup>
@@ -193,6 +196,10 @@ export default create({
       type: Boolean,
       default: true
     }, // 是否显示‘选择其他地区’按钮 type=‘exist’ 生效
+    isShowCustomBtnAndExist: {
+      type: Boolean,
+      default: false
+    }, // 是否显示一个自定义按钮 type=‘exist’ 生效
     existAddress: {
       type: Array,
       default: () => []
@@ -205,6 +212,10 @@ export default create({
       type: String,
       default: ''
     },
+    customBtnAndExistTitle: {
+      type: String,
+      default: ''
+    }, // 自定义按钮文本
     defaultIcon: {
       // 地址选择列表前 - 默认的图标
       type: String,
@@ -234,7 +245,17 @@ export default create({
       default: ''
     }
   },
-  emits: ['update:visible', 'update:modelValue', 'type', 'change', 'selected', 'close', 'close-mask', 'switch-module'],
+  emits: [
+    'update:visible',
+    'update:modelValue',
+    'type',
+    'change',
+    'selected',
+    'close',
+    'close-mask',
+    'switch-module',
+    'custom-switch-module'
+  ],
 
   setup(props, { emit }) {
     const classes = computed(() => {
@@ -527,7 +548,10 @@ export default create({
 
       emit('switch-module', { type: privateType.value });
     };
-
+    //exist方式下,单独增加一个自定义按钮
+    const customSwitchModule = () => {
+      emit('custom-switch-module', { existAddress: props.existAddress, selectedAddress: selectedExistAddress });
+    };
     const handleElevatorItem = (key: string, item: RegionData | string) => {
       nextAreaList(item);
     };
@@ -584,6 +608,9 @@ export default create({
             selectedExistAddress = item as {};
           }
         });
+      },
+      {
+        immediate: true
       }
     );
 
@@ -597,6 +624,7 @@ export default create({
       selectedRegion,
       selectedExistAddress,
       switchModule,
+      customSwitchModule,
       closeWay,
       close,
       getTabName,

--- a/src/packages/__VUE/address/index.vue
+++ b/src/packages/__VUE/address/index.vue
@@ -127,6 +127,9 @@
         <div class="choose-other" @click="switchModule" v-if="isShowCustomAddress">
           <div class="btn">{{ customAndExistTitle || translate('chooseAnotherAddress') }}</div>
         </div>
+        <div class="choose-other" @click="customSwitchModule" v-if="isShowCustomBtnAndExist">
+          <div class="btn">{{ customBtnAndExistTitle || translate('newCustomBtn') }}</div>
+        </div>
       </view>
     </view>
   </nut-popup>
@@ -190,6 +193,10 @@ export default create({
       type: Boolean,
       default: true
     }, // 是否显示‘选择其他地区’按钮 type=‘exist’ 生效
+    isShowCustomBtnAndExist: {
+      type: Boolean,
+      default: false
+    }, // 是否显示一个自定义按钮 type=‘exist’ 生效
     existAddress: {
       type: Array,
       default: () => []
@@ -202,6 +209,10 @@ export default create({
       type: String,
       default: ''
     },
+    customBtnAndExistTitle: {
+      type: String,
+      default: ''
+    }, // 自定义按钮文本
     defaultIcon: {
       // 地址选择列表前 - 默认的图标
       type: String,
@@ -231,7 +242,17 @@ export default create({
       default: ''
     }
   },
-  emits: ['update:visible', 'update:modelValue', 'type', 'change', 'selected', 'close', 'close-mask', 'switch-module'],
+  emits: [
+    'update:visible',
+    'update:modelValue',
+    'type',
+    'change',
+    'selected',
+    'close',
+    'close-mask',
+    'switch-module',
+    'custom-switch-module'
+  ],
 
   setup(props: any, { emit }) {
     const regionLine = ref<null | HTMLElement>(null);
@@ -510,6 +531,11 @@ export default create({
       emit('switch-module', { type: privateType.value });
     };
 
+    //exist方式下,单独增加一个自定义按钮
+    const customSwitchModule = () => {
+      emit('custom-switch-module', { existAddress: props.existAddress, selectedAddress: selectedExistAddress });
+    };
+
     const handleElevatorItem = (key: string, item: RegionData | string) => {
       nextAreaList(item);
     };
@@ -566,6 +592,9 @@ export default create({
             selectedExistAddress = item as {};
           }
         });
+      },
+      {
+        immediate: true
       }
     );
 
@@ -578,6 +607,7 @@ export default create({
       selectedRegion,
       selectedExistAddress,
       switchModule,
+      customSwitchModule,
       closeWay,
       close,
       getTabName,

--- a/src/packages/locale/lang/baseLang.ts
+++ b/src/packages/locale/lang/baseLang.ts
@@ -49,6 +49,7 @@ export abstract class BaseLang {
     selectRegion: string;
     deliveryTo: string;
     chooseAnotherAddress: string;
+    newCustomBtn: string;
   };
   abstract signature: {
     reSign: string;

--- a/src/packages/locale/lang/en-US.ts
+++ b/src/packages/locale/lang/en-US.ts
@@ -49,7 +49,8 @@ class Lang extends BaseLang {
   address = {
     selectRegion: 'Select Region',
     deliveryTo: 'Delivery To',
-    chooseAnotherAddress: 'Choose Another Address'
+    chooseAnotherAddress: 'Choose Another Address',
+    newCustomBtn: 'Custom Btn'
   };
   signature = {
     reSign: 'Re Sign',

--- a/src/packages/locale/lang/id-ID.ts
+++ b/src/packages/locale/lang/id-ID.ts
@@ -49,7 +49,8 @@ class Lang extends BaseLang {
   address = {
     selectRegion: 'Pilih Daerah',
     deliveryTo: 'Kirim Ke',
-    chooseAnotherAddress: 'Pilih alamat lain'
+    chooseAnotherAddress: 'Pilih alamat lain',
+    newCustomBtn: 'Tambah Alamat Baru'
   };
   signature = {
     reSign: 'Masuk Kembali',

--- a/src/packages/locale/lang/zh-CN.ts
+++ b/src/packages/locale/lang/zh-CN.ts
@@ -49,7 +49,8 @@ class Lang extends BaseLang {
   address = {
     selectRegion: '请选择所在地区',
     deliveryTo: '配送至',
-    chooseAnotherAddress: '选择其他地址'
+    chooseAnotherAddress: '选择其他地址',
+    newCustomBtn: '自定义按钮'
   };
   signature = {
     reSign: '重签',

--- a/src/packages/locale/lang/zh-TW.ts
+++ b/src/packages/locale/lang/zh-TW.ts
@@ -49,7 +49,8 @@ class Lang extends BaseLang {
   address = {
     selectRegion: '請選擇所在地區',
     deliveryTo: '配送至',
-    chooseAnotherAddress: '選擇其他地址'
+    chooseAnotherAddress: '選擇其他地址',
+    newCustomBtn: '自定义按钮'
   };
   signature = {
     reSign: '重簽',

--- a/src/sites/mobile-taro/vue/src/business/pages/address/index.vue
+++ b/src/sites/mobile-taro/vue/src/business/pages/address/index.vue
@@ -92,6 +92,27 @@
       @switch-module="switchModule"
       @close-mask="closeMask"
     ></nut-address>
+
+      <h2>已有地址自定义按钮</h2>
+    <nut-cell title="选择地址" :desc="seven" is-link @click="showAddressCustomBtn"></nut-cell>
+
+    <nut-address
+      v-model:visible="customBtn"
+      type="exist"
+      :exist-address="existAddress"
+      :province="province"
+      :city="city"
+      :country="country"
+      :town="town"
+      :back-btn-icon="backBtnIcon"
+      :is-show-custom-address="false"
+      :is-show-custom-btn-and-exist="true"
+      @change="(cal) => onChange(cal, 'customBtn')"
+      @close="close7"
+      @selected="selected"
+      @custom-switch-module="customSwitchModule"
+      @close-mask="closeMask"
+    ></nut-address>
   </div>
 </template>
 
@@ -165,6 +186,7 @@ export default defineComponent({
       exist: false,
       customImg: false,
       other: false,
+      customBtn: false,
       select: false
     });
 
@@ -217,7 +239,8 @@ export default defineComponent({
       three: '请选择地址',
       four: '请选择地址',
       five: '请选择地址',
-      six: '请选择地址'
+      six: '请选择地址',
+      seven: '请选择地址',
     });
 
     const showAddress = () => {
@@ -274,6 +297,9 @@ export default defineComponent({
     const showAddressOther = () => {
       showPopup.other = true;
     };
+    const showAddressCustomBtn = () => {
+      showPopup.customBtn = true;
+    };
     const showCustomImg = () => {
       showPopup.customImg = true;
     };
@@ -297,7 +323,15 @@ export default defineComponent({
         text.four = val.data.addressStr;
       }
     };
-
+    const close7 = (val: CalResult) => {
+      console.log(val);
+      if (val.type == 'exist') {
+        const { provinceName, cityName, countyName, townName, addressDetail } = val.data;
+        text.seven = provinceName + cityName + countyName + townName + addressDetail;
+      } else {
+        text.seven = val.data.addressStr;
+      }
+    };
     const switchModule = (val: CalResult) => {
       if (val.type == 'custom') {
         console.log('点击了“选择其他地址”按钮');
@@ -305,7 +339,10 @@ export default defineComponent({
         console.log('点击了自定义地址左上角的返回按钮');
       }
     };
-
+    const customSwitchModule = (address: any) => {
+      console.log(address);
+      console.log('点击了自定义按钮');
+    };
     const closeMask = (val: CalResult) => {
       console.log('关闭弹层', val);
     };
@@ -326,10 +363,13 @@ export default defineComponent({
       showSelected,
       existAddress,
       showAddressOther,
+      showAddressCustomBtn,
       showCustomImg,
       close3,
       close4,
+      close7,
       switchModule,
+      customSwitchModule,
       closeMask,
       placeholder,
       ...toRefs(icon),


### PR DESCRIPTION
feat:Address 新增自定义按钮;
增加按钮文本文案定义;按钮是否显示控制;按钮的事件

fix:Address type=exist 数据源selectedAddress=true时selectedExistAddress未赋值
watch props.existAddress 增加   immediate: true


<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [x] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] NutUI 2.0
- [x] NutUI 3.0 H5
- [x] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [ ] 自测 vue3 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vue3)
- [x] 自测 vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vite-ts)
- [x] 自测 taro 脚手架使用小程序 & h5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/taro)