### PR TITLE
style: fix Picker options partially overlap in older versions of Safari

### DIFF
--- a/src/packages/__VUE/oldpicker/index.scss
+++ b/src/packages/__VUE/oldpicker/index.scss
@@ -87,6 +87,8 @@
     &-item {
       display: block;
       backface-visibility: hidden;
+      -moz-backface-visibility: hidden;
+      -webkit-backface-visibility: hidden;
       position: absolute;
       top: 0;
       width: 100%;

--- a/src/packages/__VUE/picker/index.scss
+++ b/src/packages/__VUE/picker/index.scss
@@ -84,6 +84,8 @@
     &-item {
       display: block;
       backface-visibility: hidden;
+      -moz-backface-visibility: hidden;
+      -webkit-backface-visibility: hidden;
       position: absolute;
       top: 0;
       width: 100%;


### PR DESCRIPTION


**这个 PR 做了什么?** 

- fix #1457 

解决了 `Picker` 在 Safari 版本高于 5，低于 15.4 时， backface-visibility 没生效的问题。

FYI: [mdn web docs with backface-visibility](https://developer.mozilla.org/zh-CN/docs/Web/CSS/backface-visibility#%E6%B5%8F%E8%A7%88%E5%99%A8%E5%85%BC%E5%AE%B9%E6%80%A7)

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix)
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] NutUI 2.0
- [x] NutUI 3.0 H5
- [ ] NutUI 3.0 小程序

**这个 PR 是否已自测:**

没自测