### PR TITLE
fix:addresslist data list清空后不同步问题

### DIFF
--- a/src/packages/__VUE/addresslist/index.taro.vue
+++ b/src/packages/__VUE/addresslist/index.taro.vue
@@ -122,7 +122,7 @@ export default create({
     });
     //磨平参数差异
     const trowelData = () => {
-      if (Object.keys(props.dataMapOptions).length > 0 && props.data.length > 0) {
+      if (Object.keys(props.dataMapOptions).length > 0) {
         dataArray.value = props.data.map((item, index) => {
           return floatData(dataInfo, item, props.dataMapOptions);
         });

--- a/src/packages/__VUE/addresslist/index.vue
+++ b/src/packages/__VUE/addresslist/index.vue
@@ -123,7 +123,7 @@ export default create({
     //磨平参数差异
     const trowelData = () => {
       console.log('props.data', props.data);
-      if (Object.keys(props.dataMapOptions).length > 0 && props.data.length > 0) {
+      if (Object.keys(props.dataMapOptions).length > 0) {
         dataArray.value = props.data.map((item, index) => {
           return floatData(dataInfo, item, props.dataMapOptions);
         });


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://nutui.jd.com/#/contributing
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
data list清空后,没有同步列表问题


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] NutUI 2.0
- [x] NutUI 3.0 H5
- [x] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [ ] 自测 vue3 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vue3)
- [ ] 自测 vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vite-ts)
- [x] 自测 taro 脚手架使用小程序 & h5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/taro)