### PR TITLE
fix(tag): 修复 plain 与其他 prop 组合使用时未生效问题 #1472

### DIFF
--- a/src/packages/__VUE/tag/index.scss
+++ b/src/packages/__VUE/tag/index.scss
@@ -8,30 +8,50 @@
     color: $tag-default-color;
     background: $tag-default-background-color;
     border: $tag-border-width solid transparent;
+    &.nut-tag--plain {
+      color: $tag-default-background-color;
+      border: $tag-border-width solid $tag-default-background-color;
+    }
   }
 
   &--primary {
     color: $tag-default-color;
     background: $tag-primary-background-color;
     border: $tag-border-width solid transparent;
+    &.nut-tag--plain {
+      color: $tag-primary-background-color;
+      border: $tag-border-width solid $tag-primary-background-color;
+    }
   }
 
   &--success {
     color: $tag-default-color;
     background: $tag-success-background-color;
     border: $tag-border-width solid transparent;
+    &.nut-tag--plain {
+      color: $tag-success-background-color;
+      border: $tag-border-width solid $tag-success-background-color;
+    }
   }
 
   &--danger {
     color: $tag-default-color;
     background: $tag-danger-background-color;
     border: $tag-border-width solid transparent;
+    &.nut-tag--plain {
+      color: $tag-danger-background-color-plain;
+      border: $tag-border-width solid $tag-danger-background-color-plain;
+    }
   }
 
   &--warning {
     color: $tag-default-color;
     background: $tag-warning-background-color;
     border: $tag-border-width solid transparent;
+    &.nut-tag--plain {
+      color: $tag-warning-background-color;
+      border: $tag-border-width solid $tag-warning-background-color;
+    }
   }
 
   &--round {

--- a/src/packages/__VUE/tag/index.taro.vue
+++ b/src/packages/__VUE/tag/index.taro.vue
@@ -54,23 +54,18 @@ export default create({
 
     const getStyle = (): CSSProperties => {
       const style: CSSProperties = {};
-      if (color?.value) {
-        return {
-          background: color.value,
-          color: textColor.value
-        };
+      if (textColor.value) {
+        style.color = textColor.value;
+      } else if (color.value && plain.value) {
+        style.color = color.value;
       }
       if (plain.value) {
-        return {
-          color: '#FA2400',
-          background: '#fff',
-          border: '1px solid rgba(250,36,0,1)'
-        };
+        style.background = '#fff';
+        style['border-color'] = color.value;
+      } else if (color.value) {
+        style.background = color.value;
       }
-      return {
-        color: '',
-        background: ''
-      };
+      return style;
     };
 
     const onClose = (event: MouseEvent) => {

--- a/src/packages/__VUE/tag/index.vue
+++ b/src/packages/__VUE/tag/index.vue
@@ -50,25 +50,23 @@ export default create({
       };
     });
 
+    // 综合考虑 textColor、color、plain 组合使用时的效果
     const getStyle = (): CSSProperties => {
       const style: CSSProperties = {};
-      if (color?.value) {
-        return {
-          background: color.value,
-          color: textColor.value
-        };
+      // 标签内字体颜色
+      if (textColor.value) {
+        style.color = textColor.value;
+      } else if (color.value && plain.value) {
+        style.color = color.value;
       }
+      // 标签背景与边框颜色
       if (plain.value) {
-        return {
-          color: '#FA2400',
-          background: '#fff',
-          border: '1px solid rgba(250,36,0,1)'
-        };
+        style.background = '#fff';
+        style['border-color'] = color.value;
+      } else if (color.value) {
+        style.background = color.value;
       }
-      return {
-        color: '',
-        background: ''
-      };
+      return style;
     };
 
     const onClose = (event: MouseEvent) => {

--- a/src/packages/styles/variables-jdb.scss
+++ b/src/packages/styles/variables-jdb.scss
@@ -564,6 +564,7 @@ $tag-danger-background-color: linear-gradient(
   rgba(232, 34, 14, 1) 69.83950099728881%,
   rgba(242, 77, 12, 1) 100%
 ) !default;
+$tag-danger-background-color-plain: #df3526 !default;
 $tag-warning-background-color: #f3812e !default;
 $tag-default-color: #ffffff !default;
 $tag-border-width: 1px !default;

--- a/src/packages/styles/variables-jdt.scss
+++ b/src/packages/styles/variables-jdt.scss
@@ -470,6 +470,7 @@ $tag-danger-background-color: linear-gradient(
   rgba(232, 34, 14, 1) 69.83950099728881%,
   rgba(242, 77, 12, 1) 100%
 ) !default;
+$tag-danger-background-color-plain: #df3526 !default;
 $tag-warning-background-color: #f3812e !default;
 $tag-default-color: #ffffff !default;
 $tag-border-width: 1px !default;

--- a/src/packages/styles/variables.scss
+++ b/src/packages/styles/variables.scss
@@ -495,6 +495,7 @@ $tag-danger-background-color: linear-gradient(
   rgba(232, 34, 14, 1) 69.83950099728881%,
   rgba(242, 77, 12, 1) 100%
 ) !default;
+$tag-danger-background-color-plain: #df3526 !default;
 $tag-warning-background-color: #f3812e !default;
 $tag-default-color: #ffffff !default;
 $tag-border-width: 1px !default;


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)
修复多个 prop 参数组合使用时「空心」 plain 未生效的问题，并因此增加了一个全局样式变量。

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #1472
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] NutUI 2.0
- [x] NutUI 3.0 H5
- [x] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [ ] 自测 vue3 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vue3)
- [x] 自测 vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vite-ts)
- [x] 自测 taro 脚手架使用小程序 & h5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/taro)