### PR TITLE
fix(swiper): 解决PC端轮播图滑动失效问题 #1217

### DIFF
--- a/src/packages/__VUE/swiper/index.scss
+++ b/src/packages/__VUE/swiper/index.scss
@@ -5,6 +5,8 @@
   transition-property: transform;
   box-sizing: content-box;
   overflow: hidden;
+  cursor: grab;
+  user-select: none;
   &-inner {
     display: flex;
     height: 100%;

--- a/src/packages/__VUE/swiperitem/index.scss
+++ b/src/packages/__VUE/swiperitem/index.scss
@@ -1,3 +1,6 @@
 .nut-swiper-item {
   height: 100%;
+  img {
+    pointer-events: none;
+  }
 }


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)
禁用轮播图内部 img 标签的鼠标事件，解决其在 PC 端导致的滑动失效问题。

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #1217 
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] NutUI 2.0
- [x] NutUI 3.0 H5
- [ ] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [ ] 自测 vue3 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vue3)
- [x] 自测 vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vite-ts)
- [ ] 自测 taro 脚手架使用小程序 & h5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/taro)