### PR TITLE
fix(imagePreview): replace the type for images

### DIFF
--- a/src/packages/__VUE/imagepreview/doc.md
+++ b/src/packages/__VUE/imagepreview/doc.md
@@ -303,7 +303,7 @@ app.use(ImagePreview);
 |----- | ----- | ----- | ----- 
 | show | 是否展示预览图片 | Boolean | false
 | videos | 预览的视频数组（视频自动放到图片之前、taro场景暂不支持） | Array<`Object`> | []
-| images | 预览图片数组 | Array<`String`> | []
+| images | 预览图片数组 | { src: String }[] | []
 | autoplay | 自动轮播时长，0表示不会自动轮播 | Number、String  | 3000  |
 | init-no | 初始页码 | Number | 1
 | pagination-visible | 分页指示器是否展示    | Boolean | false |

--- a/src/packages/__VUE/imagepreview/index.ts
+++ b/src/packages/__VUE/imagepreview/index.ts
@@ -1,12 +1,13 @@
 import ImagePreview from './index.vue';
 import { render, createVNode, h } from 'vue';
+import { ImageInterface } from './types'
 export class ImagePreviewOptions {
-  show?: Boolean = false;
-  images?: Array<string> = [];
-  initNo?: Number = 1;
-  paginationVisible?: Boolean = false;
-  paginationColor?: string = '';
-  teleport?: String | HTMLElement = 'body';
+  show: Boolean = false;
+  images: ImageInterface[] = [];
+  initNo: Number = 1;
+  paginationVisible: Boolean = false;
+  paginationColor: string = '';
+  teleport: String | HTMLElement = 'body';
 
   // function
   onClose?: Function = () => {};

--- a/src/packages/__VUE/imagepreview/index.vue
+++ b/src/packages/__VUE/imagepreview/index.vue
@@ -55,6 +55,7 @@
 </template>
 <script lang="ts">
 import { toRefs, reactive, watch, onMounted, ref, computed } from 'vue';
+import type { PropType } from 'vue'
 import { createComponent } from '@/packages/utils/create';
 import Popup from '../popup/index.vue';
 import Video from '../video/index.vue';
@@ -63,6 +64,7 @@ import SwiperItem from '../swiperitem/index.vue';
 import Icon from '../icon/index.vue';
 import { isPromise } from '@/packages/utils/util.ts';
 import ImagePreviewItem from './imagePreviewItem.vue';
+import { ImageInterface } from './types'
 const { componentName, create } = createComponent('imagepreview');
 
 export default create({
@@ -72,7 +74,7 @@ export default create({
       default: false
     },
     images: {
-      type: Array,
+      type: Array as PropType<ImageInterface[]>,
       default: () => []
     },
     videos: {

--- a/src/packages/__VUE/imagepreview/types.ts
+++ b/src/packages/__VUE/imagepreview/types.ts
@@ -1,0 +1,3 @@
+export interface ImageInterface {
+  src: string;
+}


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)

- 修改 `ImagePreview` 组件参数 `images` 的类型定义，为了不影响原有用户升级使用，保留了 `{ src: String }[]` 这样的类型。
- fix #1477

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [x] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] NutUI 2.0
- [x] NutUI 3.0 H5
- [x] NutUI 3.0 小程序
- 应该不涉及 Taro，看文档 Taro 用了自有的 ImagePreview

**这个 PR 是否已自测:**

- [x] 自测 vue3 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vue3)
- [ ] 自测 vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vite-ts)
- [ ] 自测 taro 脚手架使用小程序 & h5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/taro)