### PR TITLE
fix(radio/layout): 相关 issues 修复 #1408 #1419

### DIFF
--- a/src/packages/__VUE/col/index.vue
+++ b/src/packages/__VUE/col/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <view :class="classes" :style="style" @click="handleClick">
+  <view :class="classes" :style="style">
     <slot></slot>
   </view>
 </template>
@@ -19,8 +19,8 @@ export default create({
       default: '0'
     }
   },
-  emits: ['click'],
-  setup(props, { emit }) {
+  emits: [],
+  setup(props) {
     const prefixCls = componentName;
     const gutter = inject('gutter') as number;
     const classes = computed(() => {
@@ -37,14 +37,9 @@ export default create({
         paddingRight: gutter / 2 + 'px'
       };
     });
-    const handleClick = (evt: MouseEvent) => {
-      evt.stopPropagation();
-      emit('click', evt);
-    };
     return {
       classes,
-      style,
-      handleClick
+      style
     };
   }
 });

--- a/src/packages/__VUE/radio/index.scss
+++ b/src/packages/__VUE/radio/index.scss
@@ -55,6 +55,7 @@
   }
 
   &__label {
+    flex: 1;
     margin-left: $radio-label-margin-left;
     font-size: $radio-label-font-size;
     color: $radio-label-font-color;

--- a/src/packages/__VUE/row/index.vue
+++ b/src/packages/__VUE/row/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <view :class="getClasses()" @click="handleClick">
+  <view :class="getClasses()">
     <slot></slot>
   </view>
 </template>
@@ -31,8 +31,8 @@ export default create({
       default: 'nowrap'
     }
   },
-  emits: ['click'],
-  setup(props, { emit }) {
+  emits: [],
+  setup(props) {
     const prefixCls = componentName;
     provide('gutter', props.gutter);
     const getClass = (prefix: string, type: string) => {
@@ -47,13 +47,8 @@ export default create({
               ${prefixCls}
               `;
     };
-    const handleClick = (evt: MouseEvent) => {
-      evt.stopPropagation();
-      emit('click', evt);
-    };
     return {
-      getClasses,
-      handleClick
+      getClasses
     };
   }
 });


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)
fix(radio): 修复 radio__label 未对齐问题 #1419
fix(layout): 移除组件内不必要的 emit(click) 并修复点击事件冒泡问题 #1408

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix)
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] NutUI 2.0
- [x] NutUI 3.0 H5
- [ ] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [ ] 自测 vue3 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vue3)
- [x] 自测 vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vite-ts)
- [ ] 自测 taro 脚手架使用小程序 & h5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/taro)