### PR TITLE
feat(icon): demo 页面增加点击图标复制 name 功能

### DIFF
--- a/src/packages/__VUE/button/index.scss
+++ b/src/packages/__VUE/button/index.scss
@@ -15,6 +15,7 @@
   appearance: none;
   user-select: none;
   touch-action: manipulation;
+  vertical-align: bottom;
 
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
   -webkit-tap-highlight-color: transparent;

--- a/src/packages/__VUE/icon/demo.vue
+++ b/src/packages/__VUE/icon/demo.vue
@@ -30,7 +30,7 @@
     <nut-cell-group v-for="item in icons.data" :title="currentLang == 'zh-CN' ? item.name : item.nameEn" :key="item">
       <nut-cell>
         <ul>
-          <li v-for="item in item.icons" :key="item" @click="copyText(item)">
+          <li v-for="item in item.icons" :key="item" @click="copyTag(item)">
             <nut-icon :name="item"></nut-icon>
             <span>{{ item }}</span>
           </li>
@@ -40,7 +40,7 @@
     <nut-cell-group v-for="item in icons.style" :title="currentLang == 'zh-CN' ? item.name : item.nameEn" :key="item">
       <nut-cell>
         <ul>
-          <li v-for="it in item.icons" :key="it" @click="copyText(it['animation-name'])">
+          <li v-for="it in item.icons" :key="it" @click="copyTag(it['animation-name'])">
             <nut-icon :name="it.name" :class="`nut-icon-${it['animation-name']} nut-icon-${it['animation-time']}`">
             </nut-icon>
             <span>{{ it['animation-name'] }}</span>
@@ -79,18 +79,19 @@ export default createDemo({
   props: {},
   setup() {
     initTranslate();
-    const copyText = (text: string) => {
+    const copyTag = (name: string) => {
+      const text = `&lt;nut-icon name="${name}"&gt;&lt;/nut-icon&gt;`;
       const input = document.createElement('input');
       document.body.appendChild(input);
       input.setAttribute('value', text);
       input.select();
       if (document.execCommand('copy')) {
         document.execCommand('copy');
-        Toast.text(translate('copyToast'));
+        Toast.text(`${translate('copyToast')}: <br/>${text}`);
       }
       document.body.removeChild(input);
     };
-    return { icons, translate, currentLang, copyText };
+    return { icons, translate, currentLang, copyTag };
   }
 });
 </script>

--- a/src/packages/__VUE/icon/demo.vue
+++ b/src/packages/__VUE/icon/demo.vue
@@ -30,7 +30,7 @@
     <nut-cell-group v-for="item in icons.data" :title="currentLang == 'zh-CN' ? item.name : item.nameEn" :key="item">
       <nut-cell>
         <ul>
-          <li v-for="item in item.icons" :key="item">
+          <li v-for="item in item.icons" :key="item" @click="copyText(item)">
             <nut-icon :name="item"></nut-icon>
             <span>{{ item }}</span>
           </li>
@@ -40,7 +40,7 @@
     <nut-cell-group v-for="item in icons.style" :title="currentLang == 'zh-CN' ? item.name : item.nameEn" :key="item">
       <nut-cell>
         <ul>
-          <li v-for="it in item.icons" :key="it">
+          <li v-for="it in item.icons" :key="it" @click="copyText(it['animation-name'])">
             <nut-icon :name="it.name" :class="`nut-icon-${it['animation-name']} nut-icon-${it['animation-time']}`">
             </nut-icon>
             <span>{{ it['animation-name'] }}</span>
@@ -59,24 +59,38 @@ const initTranslate = () =>
       basic: '基本用法',
       imageLink: '图片链接',
       iconColor: '图标颜色',
-      iconSize: '图标大小'
+      iconSize: '图标大小',
+      copyToast: '复制成功'
     },
     'en-US': {
       basic: 'Basic Usage',
       imageLink: 'Image Link',
       iconColor: 'Icon Color',
-      iconSize: 'Icon Size'
+      iconSize: 'Icon Size',
+      copyToast: 'Copied successfully'
     }
   });
 // import icons from '@/packages/styles/font/iconfont.json';
 import icons from '@/packages/styles/font/config.json';
 import { createComponent } from '@/packages/utils/create';
 const { createDemo, translate } = createComponent('icon');
+import { Toast } from '@/packages/nutui.vue';
 export default createDemo({
   props: {},
   setup() {
     initTranslate();
-    return { icons, translate, currentLang };
+    const copyText = (text: string) => {
+      const input = document.createElement('input');
+      document.body.appendChild(input);
+      input.setAttribute('value', text);
+      input.select();
+      if (document.execCommand('copy')) {
+        document.execCommand('copy');
+        Toast.text(translate('copyToast'));
+      }
+      document.body.removeChild(input);
+    };
+    return { icons, translate, currentLang, copyText };
   }
 });
 </script>


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)
feat(icon): demo 页面增加点击图标复制 name 功能
fix(button): 修复带 icon 的 button 基线发生变化的问题
![image](https://user-images.githubusercontent.com/44915689/184834251-20ba5ca4-9be3-4da0-8f10-b41654a7f0d5.png)

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix)
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] NutUI 2.0
- [x] NutUI 3.0 H5
- [ ] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [ ] 自测 vue3 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vue3)
- [x] 自测 vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vite-ts)
- [ ] 自测 taro 脚手架使用小程序 & h5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/taro)