### PR TITLE
fix(form&radio): 修复 radio 表单校验相关问题

### DIFF
--- a/src/packages/__VUE/form/common.ts
+++ b/src/packages/__VUE/form/common.ts
@@ -87,7 +87,7 @@ export const component = {
         const { required, validator, regex, message } = _rules.shift() as FormItemRule;
         const errorMsg = { prop, message };
         if (required) {
-          if (!value) {
+          if (value === '' || value === undefined || value === null) {
             return _Promise(errorMsg);
           }
         }

--- a/src/packages/__VUE/radio/index.taro.vue
+++ b/src/packages/__VUE/radio/index.taro.vue
@@ -43,7 +43,7 @@ export default create({
     let parent: any = inject('parent', null);
 
     const isCurValue = computed(() => {
-      return parent.label.value == props.label;
+      return parent.label.value === props.label;
     });
 
     const color = computed(() => {

--- a/src/packages/__VUE/radio/index.taro.vue
+++ b/src/packages/__VUE/radio/index.taro.vue
@@ -15,7 +15,7 @@ export default create({
       default: 'round' // button
     },
     label: {
-      type: [String, Number],
+      type: [String, Number, Boolean],
       default: ''
     },
     iconName: {

--- a/src/packages/__VUE/radio/index.vue
+++ b/src/packages/__VUE/radio/index.vue
@@ -43,7 +43,7 @@ export default create({
     let parent: any = inject('parent', null);
 
     const isCurValue = computed(() => {
-      return parent.label.value == props.label;
+      return parent.label.value === props.label;
     });
 
     const color = computed(() => {

--- a/src/packages/__VUE/radio/index.vue
+++ b/src/packages/__VUE/radio/index.vue
@@ -15,7 +15,7 @@ export default create({
       default: 'round' // button
     },
     label: {
-      type: [String, Number],
+      type: [String, Number, Boolean],
       default: ''
     },
     iconName: {


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)
fix(form&radio): 修复表单校验时 0 与 false 被判断为空的问题 #1574 
fix(radio): 修复 prop-label 不支持 boolean 类型的问题 #1575 

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] NutUI 2.0
- [x] NutUI 3.0 H5
- [x] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [ ] 自测 vue3 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vue3)
- [x] 自测 vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vite-ts)
- [ ] 自测 taro 脚手架使用小程序 & h5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/taro)