### PR TITLE
fix: 修复 ImagePreview 在Taro编译成H5后报错的问题

### DIFF
--- a/src/packages/__VUE/imagepreview/index.taro.vue
+++ b/src/packages/__VUE/imagepreview/index.taro.vue
@@ -14,15 +14,13 @@
         :pagination-visible="paginationVisible"
         :pagination-color="paginationColor"
       >
-        <!-- <nut-swiper-item v-for="(item, index) in videos" :key="index">
-          <nut-video :source="item.source" :options="item.options"></nut-video>
-        </nut-swiper-item> -->
         <nut-swiper-item v-for="(item, index) in images" :key="index">
-          <image mode="aspectFit" :src="item.src" class="nut-imagepreview-img" />
+          <!-- <image mode="aspectFit" :src="item.src" class="nut-imagepreview-img" /> -->
+          <img :src="item.src" mode="aspectFit" class="nut-imagepreview-img" />
         </nut-swiper-item>
       </nut-swiper>
     </view>
-    <!-- <view class="nut-imagepreview-index"> {{ active }} / {{ images.length + videos.length }} </view> -->
+
     <view class="nut-imagepreview-index" v-if="showIndex"> {{ active }} / {{ images.length }} </view>
     <view class="nut-imagepreview-close-icon" @click="handleCloseIcon" :style="styles" v-if="closeable"
       ><nut-icon :name="closeIcon" v-bind="$attrs" color="#ffffff"></nut-icon


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://nutui.jd.com/#/contributing
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)



**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] NutUI 2.0
- [ ] NutUI 3.0 H5
- [x] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [ ] 自测 vue3 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vue3)
- [ ] 自测 vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vite-ts)
- [ ] 自测 taro 脚手架使用小程序 & h5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/taro)