### PR TITLE
fix: close事件触发时机

### DIFF
--- a/src/packages/__VUE/popup/index.taro.vue
+++ b/src/packages/__VUE/popup/index.taro.vue
@@ -148,10 +148,10 @@ export default create({
       if (props.visible) {
         unlockScroll();
         emit('update:visible', false);
+        emit('close');
         if (props.destroyOnClose) {
           setTimeout(() => {
             state.showSlot = false;
-            emit('close');
           }, +props.duration * 1000);
         }
       }

--- a/src/packages/__VUE/popup/index.vue
+++ b/src/packages/__VUE/popup/index.vue
@@ -196,10 +196,10 @@ export default create({
     const close = () => {
       unlockScroll();
       emit('update:visible', false);
+      emit('close');
       if (props.destroyOnClose) {
         setTimeout(() => {
           state.showSlot = false;
-          emit('close');
         }, +props.duration * 1000);
       }
     };


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://nutui.jd.com/#/contributing
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
### Popup组件
```javascript
    const close = () => {
      unlockScroll();
      emit('update:visible', false);
      emit('close'); // 应该放在这里
      if (props.destroyOnClose) {
        setTimeout(() => {
          emit('close'); // 不应该放在这里
          state.showSlot = false;
        }, +props.duration * 1000);
      }
    };
```
emit('close')时机不对，假设设置了destroyOnClose = false，将意味用户无法监听到close事件，并完成相应的关闭回调逻辑。


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] NutUI 2.0
- [x] NutUI 3.0 H5
- [x] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [ ] 自测 vue3 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vue3)
- [ ] 自测 vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vite-ts)
- [x] 自测 taro 脚手架使用小程序 & h5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/taro)