### PR TITLE
:fix:修复Address组件点击遮罩层回调触发两次问题

### DIFF
--- a/src/packages/__VUE/popup/index.vue
+++ b/src/packages/__VUE/popup/index.vue
@@ -199,7 +199,6 @@ export default create({
       if (props.destroyOnClose) {
         setTimeout(() => {
           state.showSlot = false;
-          emit('close');
         }, +props.duration * 1000);
       }
     };


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://nutui.jd.com/#/contributing
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
Popup组件 
```
const close = () => {
      unlockScroll();
      emit('update:visible', false);
      if (props.destroyOnClose) {
        setTimeout(() => {
          state.showSlot = false;
          //  emit('close'); // 这里会重复调触发close事件 
        }, +props.duration * 1000);
      }
    };
```
Address组件
``` 
 watch(
      () => showPopup.value,
      (value) => {
        if (value == false) {
          close(); //这里也调用一次
        } else {
          initCustomSelected();
        }
      }
    );
```

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #1731
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] NutUI 2.0
- [x] NutUI 3.0 H5
- [x] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [ ] 自测 vue3 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vue3)
- [ ] 自测 vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vite-ts)
- [x] 自测 taro 脚手架使用小程序 & h5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/taro)