### PR TITLE
fix: tabbar safe-bottom样式异常

### DIFF
--- a/src/packages/__VUE/tabbar/index.scss
+++ b/src/packages/__VUE/tabbar/index.scss
@@ -12,7 +12,7 @@
   display: flex;
   align-items: center;
   height: 50px;
-  box-sizing: border-box;
+  box-sizing: content-box;
   background: $white;
 
   &:last-child {

--- a/src/packages/__VUE/tabbaritem/index.scss
+++ b/src/packages/__VUE/tabbaritem/index.scss
@@ -72,6 +72,7 @@
       display: block;
       background-size: 100% 100%;
       background-position: center center;
+      margin-bottom: 4px;
     }
     &_nav-word {
       font-size: $tabbar-item-text-font-size;


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://nutui.jd.com/#/zh-CN/guide/contributing
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

1  修复tabbars使用safe-area-inset-bottom时样式异常
固定了tabbar高度, 当padding-bottom: env(safe-area-inset-bottom); 取值不为0时候, 样式会出现异常

2 增加icon和text之间的间距,样式优化


**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] NutUI 2.0
- [x] NutUI 3.0 H5
- [x] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [x] 自测 vue3 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vue3)
- [x] 自测 vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vite-ts)
- [x] 自测 taro 脚手架使用小程序 & h5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/taro)