### PR TITLE
fix(textarea): 小程序端组件按需加载的时候，未正确获取到文本框的高度

### DIFF
--- a/src/packages/__VUE/textarea/index.taro.vue
+++ b/src/packages/__VUE/textarea/index.taro.vue
@@ -200,16 +200,13 @@ export default create({
     const env = Taro.getEnv();
     onMounted(() => {
       if (props.autosize) {
-        eventCenter.once((getCurrentInstanceTaro() as any).router.onReady, () => {
+        Taro.nextTick(() => {
           if (Taro.getEnv() === 'ALIPAY') {
             getRefWidth();
             copyHeight();
           } else {
             getRefHeight();
           }
-          // setTimeout(() => {
-          //   nextTick(getContentHeight);
-          // }, 300);
         });
       }
     });


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://nutui.jd.com/#/zh-CN/guide/contributing
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

使用 Taro.nextTick 模拟小程序环境页面 onReady，具体查看https://nervjs.github.io/taro-docs/docs/vue-page#onready-

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] NutUI 2.0
- [ ] NutUI 3.0 H5
- [x] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [ ] 自测 vue3 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vue3)
- [ ] 自测 vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vite-ts)
- [x] 自测 taro 脚手架使用小程序 & h5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/taro)