### PR TITLE
fix(card): too much content causes image stretched

### DIFF
--- a/src/packages/__VUE/card/index.scss
+++ b/src/packages/__VUE/card/index.scss
@@ -12,6 +12,7 @@
 
   .nut-card__left {
     width: 120px;
+    height: 120px;
     flex-shrink: 0;
     background-color: $card-left-background-color;
     border-radius: $card-left-border-radius;


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://nutui.jd.com/#/zh-CN/guide/contributing
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

商品卡片，图片会由于右侧内容拉高而随之拉伸。（如修改右侧内容的文本、字体尺寸等，demo示例可见”自定义商品标签“）

目前通过固定图片高度解决。

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] NutUI 2.0
- [x] NutUI 3.0 H5
- [x] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [ ] 自测 vue3 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vue3-vue-cli)
- [ ] 自测 vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vite-ts)
- [ ] 自测 taro 脚手架使用小程序 & h5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/taro)