### PR TITLE
fix: 修复 H5 下向上展开样式错误

### DIFF
--- a/src/packages/__VUE/menuitem/index.scss
+++ b/src/packages/__VUE/menuitem/index.scss
@@ -53,7 +53,7 @@
 
 .nut-menu__overlay {
   position: absolute !important;
-  top: auto !important;
+  top: auto;
 }
 
 .placeholder-element {

--- a/src/packages/__VUE/menuitem/index.scss
+++ b/src/packages/__VUE/menuitem/index.scss
@@ -53,6 +53,7 @@
 
 .nut-menu__overlay {
   position: absolute !important;
+  top: auto !important;
 }
 
 .placeholder-element {


### PR DESCRIPTION
fix: 修复 H5 下向上展开样式错误

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] NutUI 2.0
- [x] NutUI 3.0 H5
- [x] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [ ] 自测 vue3 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vue3-vue-cli)
- [x] 自测 vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vite-ts)
- [x] 自测 taro 脚手架使用小程序 & h5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/taro)