### PR TITLE
fix: 修改水印导出名称

### DIFF
--- a/src/packages/__VUE/watermark/doc.md
+++ b/src/packages/__VUE/watermark/doc.md
@@ -10,12 +10,12 @@
 
 import { createApp } from 'vue';
 // vue
-import { Watermark } from '@nutui/nutui';
+import { WaterMark } from '@nutui/nutui';
 // taro
-import { Watermark } from '@nutui/nutui-taro';
+import { WaterMark } from '@nutui/nutui-taro';
 
 const app = createApp();
-app.use(Watermark);
+app.use(WaterMark);
 
 ```
 


### PR DESCRIPTION
水印的导出名称应该为WaterMark，不是 Watermark

<!--
请务必阅读贡献者指南:
https://nutui.jd.com/#/zh-CN/guide/contributing
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

水印的导出名称应该为WaterMark，不是 Watermark

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] NutUI 2.0
- [ ] NutUI 3.0 H5
- [x] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [ ] 自测 vue3 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vue3-vue-cli)
- [ ] 自测 vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vite-ts)
- [ ] 自测 taro 脚手架使用小程序 & h5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/taro)