### PR TITLE
fix(tabs): the wrong position of smile curve

### DIFF
--- a/src/packages/__VUE/tabs/index.scss
+++ b/src/packages/__VUE/tabs/index.scss
@@ -67,9 +67,7 @@
           .nut-tabs__titles-item__smile {
             right: -2px;
             bottom: 2px;
-            left: auto;
             width: 3px;
-            transform: rotate(320deg);
             height: $tabs-vertical-titles-item-active-line-height;
           }
         }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://nutui.jd.com/#/zh-CN/guide/contributing
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

修复官方文档中tabs组件展示demo里左右布局-微笑曲线位置错误的问题。H5和小程序端均显示正常。

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] NutUI 2.0
- [x] NutUI 3.0 H5
- [ ] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [ ] 自测 vue3 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vue3-vue-cli)
- [ ] 自测 vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vite-ts)
- [ ] 自测 taro 脚手架使用小程序 & h5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/taro)