### PR TITLE
feat(tabs): the title bar supports automatic scrolling

### DIFF
--- a/src/packages/__VUE/tabs/doc.en-US.md
+++ b/src/packages/__VUE/tabs/doc.en-US.md
@@ -169,6 +169,8 @@ export default {
 
 ### A large number of scrolling operations
 
+In the `taro` environment, `name` must be set to enable the automatic scrolling function of the title bar.
+
 :::demo
 ```html
 <template>
@@ -346,6 +348,7 @@ export default {
 | auto-height   | Automatic height. When set to `true`, `nut-tabs` and `nut-tabs__content` will change with the height of the current `nut-tab-pane`. | boolean          | `false`      |
 | sticky        | Whether to use sticky mode                                                                                                          | boolean          | `false`      |
 | top           | Sticky offset top                                                                                                                   | number           | `0`          |
+| name        | In the `taro` environment, `name` must be set to enable the automatic scrolling function of the title bar.                              | string | ''        |
 
 ### Tabs Slots
 

--- a/src/packages/__VUE/tabs/doc.md
+++ b/src/packages/__VUE/tabs/doc.md
@@ -169,10 +169,12 @@ export default {
 
 ### 数量多,滚动操作
 
+在`taro`环境下，必须设置`name`以开启标题栏自动滚动功能。
+
 :::demo
 ```html
 <template>
-<nut-tabs v-model="state.tab4value" title-scroll title-gutter="10">
+<nut-tabs v-model="state.tab4value" title-scroll title-gutter="10" name="tab4value">
   <nut-tab-pane v-for="item in state.list4" :title="'Tab '+ item">
     Tab {{item}}
   </nut-tab-pane>
@@ -346,6 +348,7 @@ export default {
 | auto-height   | 自动高度。设置为 true 时，nut-tabs 和 nut-tabs__content 会随着当前 nut-tab-pane 的高度而发生变化。 | boolean          | `false`      |
 | sticky        | 是否使用粘性布局                                                                                   | boolean          | `false`      |
 | top           | 粘性布局下的吸顶距离                                                                               | number           | `0`          |
+| name        | 在`taro`环境下，必须设置`name`以开启标题栏自动滚动功能。                              | string | ''        |
 
 ### Tabs Slots
 

--- a/src/packages/__VUE/tabs/doc.taro.md
+++ b/src/packages/__VUE/tabs/doc.taro.md
@@ -169,10 +169,12 @@ export default {
 
 ### 数量多,滚动操作
 
+在`taro`环境下，必须设置`name`以开启标题栏自动滚动功能。
+
 :::demo
 ```html
 <template>
-<nut-tabs v-model="state.tab4value" title-scroll title-gutter="10">
+<nut-tabs v-model="state.tab4value" title-scroll title-gutter="10" name="tab4value">
   <nut-tab-pane v-for="item in state.list4" :title="'Tab '+ item">
     Tab {{item}}
   </nut-tab-pane>
@@ -344,6 +346,7 @@ export default {
 | title-gutter  | 标签间隙                                                                                           | number \| string | `0`          |
 | size          | 标签栏字体尺寸大小 可选值  large normal small                                                      | string           | `normal`     |
 | auto-height   | 自动高度。设置为 true 时，nut-tabs 和 nut-tabs__content 会随着当前 nut-tab-pane 的高度而发生变化。 | boolean          | `false`      |
+| name        | 在`taro`环境下，必须设置`name`以开启标题栏自动滚动功能。                              | string | ''        |
 
 ### Tabs Slots
 

--- a/src/packages/__VUE/tabs/index.scss
+++ b/src/packages/__VUE/tabs/index.scss
@@ -191,3 +191,16 @@
     box-sizing: border-box;
   }
 }
+.tabs-scrollview {
+  white-space: nowrap;
+}
+.nut-tabs__titles-item {
+  &.nut-tabs__titles-placeholder {
+    width: auto;
+    min-width: 10px;
+  }
+  .taro {
+    height: 46px;
+    line-height: 46px;
+  }
+}

--- a/src/packages/__VUE/tabs/types.ts
+++ b/src/packages/__VUE/tabs/types.ts
@@ -1,0 +1,10 @@
+export type RectItem = {
+  bottom: number;
+  dataset: { sid: string };
+  height: number;
+  id: string;
+  left: number;
+  right: number;
+  top: number;
+  width: number;
+};

--- a/src/sites/mobile-taro/vue/src/nav/pages/tabs/index.vue
+++ b/src/sites/mobile-taro/vue/src/nav/pages/tabs/index.vue
@@ -36,7 +36,7 @@
     </nut-tabs>
 
     <h2>数量多,滚动操作</h2>
-    <nut-tabs v-model="state.tab4value" title-scroll title-gutter="10">
+    <nut-tabs v-model="state.tab4value" title-scroll title-gutter="10" name="tab4value">
       <nut-tab-pane v-for="item in state.list4" :title="'Tab ' + item"> Tab {{ item }} </nut-tab-pane>
     </nut-tabs>
     <h2>左右布局</h2>


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://nutui.jd.com/#/zh-CN/guide/contributing
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

点击某个tab时title bar自动滚动到可视区域中间位置。

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] NutUI 2.0
- [ ] NutUI 3.0 H5
- [ ] NutUI 3.0 小程序
- [x] NutUI 4.0 H5
- [x] NutUI 4.0 小程序

**这个 PR 是否已自测:**

- [ ] 自测 vue3 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vue3-vue-cli)
- [ ] 自测 vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vite-ts)
- [ ] 自测 taro 脚手架使用小程序 & h5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/taro)