### PR TITLE
fix: tabbar and tabbaritem can not render in weapp

### DIFF
--- a/src/packages/__VUE/tabbar/index.taro.vue
+++ b/src/packages/__VUE/tabbar/index.taro.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="{ 'nut-tabbar__placeholder': bottom && placeholder }" :style="{ height: height + 'px' }">
+  <view :class="{ 'nut-tabbar__placeholder': bottom && placeholder }" :style="{ height: height + 'px' }">
     <view
       ref="nutTabbar"
       class="nut-tabbar"
@@ -7,7 +7,7 @@
     >
       <slot></slot>
     </view>
-  </div>
+  </view>
 </template>
 
 <script lang="ts">

--- a/src/packages/__VUE/tabbaritem/index.taro.vue
+++ b/src/packages/__VUE/tabbaritem/index.taro.vue
@@ -1,5 +1,5 @@
 <template>
-  <div
+  <view
     class="nut-tabbar-item"
     :class="{ 'nut-tabbar-item__icon--unactive': !active }"
     :style="{
@@ -9,9 +9,9 @@
   >
     <nut-badge v-bind="$attrs">
       <view class="nut-tabbar-item_icon-box">
-        <div class="nut-tabbar-item_icon-box_icon" v-if="isHaveSlot('icon')">
+        <view class="nut-tabbar-item_icon-box_icon" v-if="isHaveSlot('icon')">
           <slot name="icon" :active="active"></slot>
-        </div>
+        </view>
         <view v-if="icon && !isHaveSlot('icon')">
           <component :is="renderIcon(icon)" class="nut-popover-item-img"></component>
         </view>
@@ -28,7 +28,7 @@
         </view>
       </view>
     </nut-badge>
-  </div>
+  </view>
 </template>
 <script lang="ts">
 import { createComponent, renderIcon } from '@/packages/utils/create';


### PR DESCRIPTION
because the div is not a valid tag in miniapp

<!--
请务必阅读贡献者指南:
https://nutui.jd.com/#/zh-CN/guide/contributing
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
修复了 tabbar 和 tabbaritem 在小程序无法渲染的问题


**这个 PR 是什么类型?** (至少选择一个)

- [X] 错误修复(Bugfix) issue id #2154
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] NutUI 2.0
- [ ] NutUI 3.0 H5
- [ ] NutUI 3.0 小程序
- [ ] NutUI 4.0 H5
- [X] NutUI 4.0 小程序

**这个 PR 是否已自测:**

- [ ] 自测 vue3 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vue3-vue-cli)
- [ ] 自测 vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vite-ts)
- [x] 自测 taro 脚手架使用小程序 & h5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/taro)