### PR TITLE
fix: make peer dep optional

### DIFF
--- a/publish/nutui-taro/package.json
+++ b/publish/nutui-taro/package.json
@@ -46,6 +46,11 @@
   "peerDependencies": {
     "unplugin-vue-components": "^0.23.0"
   },
+  "peerDependenciesMeta": {
+    "unplugin-vue-components": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "sass": "^1.50.0",
     "@nutui/icons-vue-taro": "^0.0.9"

--- a/publish/nutui/package.json
+++ b/publish/nutui/package.json
@@ -39,6 +39,11 @@
   "peerDependencies": {
     "unplugin-vue-components": "^0.23.0"
   },
+  "peerDependenciesMeta": {
+    "unplugin-vue-components": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "sass": "^1.50.0",
     "@nutui/icons-vue": "^0.0.26"


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://nutui.jd.com/#/zh-CN/guide/contributing
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

NutUI v4 中，使用 `unplugin-vue-components` 仍然是可选的，所以它应该是可选的 `peerDependencies `。

否则若不使用 `unplugin-vue-components`，使用 pnpm 安装 NutUI 时会报警告。

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] NutUI 2.0
- [ ] NutUI 3.0 H5
- [ ] NutUI 3.0 小程序
- [x] NutUI 4.0 H5
- [x] NutUI 4.0 小程序

**这个 PR 是否已自测:**

- [ ] 自测 vue3 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vue3-vue-cli)
- [ ] 自测 vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vite-ts)
- [ ] 自测 taro 脚手架使用小程序 & h5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/taro)