### PR TITLE
fix(input): 修复 input 校验格式化错误 #2178

### DIFF
--- a/src/packages/__VUE/input/index.taro.vue
+++ b/src/packages/__VUE/input/index.taro.vue
@@ -225,15 +225,15 @@ export default create({
     const _onInput = (event: Event) => {
       const input = event.target as HTMLInputElement;
       let value = input.value;
-      if (props.maxLength && value.length > Number(props.maxLength)) {
-        value = value.slice(0, Number(props.maxLength));
-      }
       updateValue(value);
     };
 
     const updateValue = (value: string, trigger: InputFormatTrigger = 'onChange') => {
       // #2178 & Taro #2642
       emit('update:modelValue', value);
+      if (props.maxLength && value.length > Number(props.maxLength)) {
+        value = value.slice(0, Number(props.maxLength));
+      }
       if (props.type === 'digit') {
         value = formatNumber(value, false, false);
       }

--- a/src/packages/__VUE/input/index.taro.vue
+++ b/src/packages/__VUE/input/index.taro.vue
@@ -232,19 +232,16 @@ export default create({
     };
 
     const updateValue = (value: string, trigger: InputFormatTrigger = 'onChange') => {
+      // #2178 & Taro #2642
+      emit('update:modelValue', value);
       if (props.type === 'digit') {
         value = formatNumber(value, false, false);
       }
       if (props.type === 'number') {
         value = formatNumber(value, true, true);
       }
-
       if (props.formatter && trigger === props.formatTrigger) {
         value = props.formatter(value);
-      }
-
-      if (inputRef?.value.value !== value) {
-        inputRef.value.value = value;
       }
       if (value !== props.modelValue) {
         emit('update:modelValue', value);


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://nutui.jd.com/#/zh-CN/guide/contributing
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

修复 input 组件修改值失败的问题

- 可能的问题原因：
    - Taro Vue 下直接修改 inputRef.value.value 会报错 ？
    - Taro input 组件受控方式，无法一次性 update:modelValue 成功

- 参考：https://github.com/NervJS/taro/issues/2642

修复后，不影响 Taro H5、小程序下的校验格式化功能

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] NutUI 2.0
- [ ] NutUI 3.0 H5
- [ ] NutUI 3.0 小程序
- [ ] NutUI 4.0 H5
- [x] NutUI 4.0 小程序

**这个 PR 是否已自测:**

- [ ] 自测 vue3 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vue3-vue-cli)
- [ ] 自测 vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vite-ts)
- [x] 自测 taro 脚手架使用小程序 & h5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/taro)