### PR TITLE
fix(switch): inactiveValue 为非 falsy 值无法显示

### DIFF
--- a/src/packages/__VUE/switch/__tests__/switch.spec.ts
+++ b/src/packages/__VUE/switch/__tests__/switch.spec.ts
@@ -51,6 +51,19 @@ test('prop activeText test', () => {
   expect(wrapper.html()).toContain('test text');
 });
 
+test('prop activeValue test', () => {
+  const wrapper = mount(Switch, {
+    props: {
+      modelValue: '0',
+      activeText: '开',
+      activeValue: '1',
+      inactiveText: '关',
+      inactiveValue: '0'
+    }
+  });
+  expect(wrapper.find('.close').isVisible()).toBeTruthy();
+});
+
 test('emit click event', () => {
   const wrapper = mount(Switch);
 

--- a/src/packages/__VUE/switch/index.taro.vue
+++ b/src/packages/__VUE/switch/index.taro.vue
@@ -5,8 +5,8 @@
         <Loading1 name="loading1" :color="activeColor" />
       </slot>
       <template v-if="activeText">
-        <view class="nut-switch-label open" v-show="modelValue">{{ activeText }}</view>
-        <view class="nut-switch-label close" v-show="!modelValue">{{ inactiveText }}</view>
+        <view class="nut-switch-label open" v-show="isActive">{{ activeText }}</view>
+        <view class="nut-switch-label close" v-show="!isActive">{{ inactiveText }}</view>
       </template>
     </view>
   </view>
@@ -101,6 +101,7 @@ export default create({
     return {
       classes,
       style,
+      isActive,
       onClick
     };
   }

--- a/src/packages/__VUE/switch/index.vue
+++ b/src/packages/__VUE/switch/index.vue
@@ -5,8 +5,8 @@
         <Loading1 name="loading" :color="activeColor" />
       </slot>
       <template v-if="activeText">
-        <view class="nut-switch-label open" v-show="modelValue">{{ activeText }}</view>
-        <view class="nut-switch-label close" v-show="!modelValue">{{ inactiveText }}</view>
+        <view class="nut-switch-label open" v-show="isActive">{{ activeText }}</view>
+        <view class="nut-switch-label close" v-show="!isActive">{{ inactiveText }}</view>
       </template>
     </view>
   </view>
@@ -101,6 +101,7 @@ export default create({
     return {
       classes,
       style,
+      isActive,
       onClick
     };
   }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://nutui.jd.com/#/zh-CN/guide/contributing
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

修复 Switch 组件 inactiveValue 为非 falsy 值时 inactiveText无法显示

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #2252
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [ ] NutUI 2.0
- [ ] NutUI 3.0 H5
- [ ] NutUI 3.0 小程序
- [x] NutUI 4.0 H5
- [x] NutUI 4.0 小程序

**这个 PR 是否已自测:**

- [ ] 自测 vue3 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vue3-vue-cli)
- [x] 自测 vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vite-ts)
- [x] 自测 taro 脚手架使用小程序 & h5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/taro)