### PR TITLE
fix(checkbox): fix the icon display about indeterminate

### DIFF
--- a/src/packages/__VUE/checkbox/common.ts
+++ b/src/packages/__VUE/checkbox/common.ts
@@ -59,10 +59,10 @@ export const component = (componentName: string, components: Record<string, Comp
 
       const color = computed(() => {
         return !pDisabled.value
-          ? !pValue.value
-            ? 'nut-checkbox__icon--unchecked'
-            : state.partialSelect
+          ? state.partialSelect
             ? 'nut-checkbox__icon--indeterminate'
+            : !pValue.value
+            ? 'nut-checkbox__icon--unchecked'
             : 'nut-checkbox__icon'
           : 'nut-checkbox__icon--disable';
       });
@@ -93,10 +93,10 @@ export const component = (componentName: string, components: Record<string, Comp
           Checked: slots.checkedIcon ? slots.checkedIcon : components.Checked,
           CheckDisabled: slots.indeterminate ? slots.indeterminate : components.CheckDisabled
         };
-        const iconNode = !pValue.value
-          ? iconNodeMap.CheckNormal
-          : state.partialSelect
+        const iconNode = state.partialSelect
           ? iconNodeMap.CheckDisabled
+          : !pValue.value
+          ? iconNodeMap.CheckNormal
           : iconNodeMap.Checked;
         const size = pxCheck(iconSize);
         return h(iconNode, {

--- a/src/packages/__VUE/checkbox/demo.vue
+++ b/src/packages/__VUE/checkbox/demo.vue
@@ -225,7 +225,7 @@ export default createDemo({
         { label: '5', value: translate('combine') },
         { label: '6', value: translate('combine') }
       ],
-      indeterminate: true
+      indeterminate: false
     });
     const changeBox1 = (state: boolean, label: string) => {
       console.log(state, label);
@@ -254,6 +254,7 @@ export default createDemo({
       } else if (label.length && label.length < 4) {
         data.indeterminate = true;
       } else {
+        data.indeterminate = false;
         data.checkbox10 = false;
       }
     };

--- a/src/packages/__VUE/checkbox/doc.en-US.md
+++ b/src/packages/__VUE/checkbox/doc.en-US.md
@@ -378,7 +378,7 @@ When the value changes, the `change` event will be triggered
     setup() {
       const group2 = ref(null) as Ref;
       const state = reactive({
-        indeterminate: true,
+        indeterminate: false,
         checkbox10: false,
         checkboxgroup5: [],
       });
@@ -394,6 +394,7 @@ When the value changes, the `change` event will be triggered
         } else if(label.length && label.length < 4){
           state.indeterminate = true;
         } else {
+          data.indeterminate = false;
           state.checkbox10 = false;
         }
       };

--- a/src/packages/__VUE/checkbox/doc.md
+++ b/src/packages/__VUE/checkbox/doc.md
@@ -380,7 +380,7 @@ app.use(CheckboxGroup);
     setup() {
       const group2 = ref(null) as Ref;
       const state = reactive({
-        indeterminate: true,
+        indeterminate: false,
         checkbox10: false,
         checkboxgroup5: [],
       });
@@ -396,6 +396,7 @@ app.use(CheckboxGroup);
         } else if(label.length && label.length < 4){
           state.indeterminate = true;
         } else {
+          data.indeterminate = false;
           state.checkbox10 = false;
         }
       };

--- a/src/packages/__VUE/checkbox/doc.taro.md
+++ b/src/packages/__VUE/checkbox/doc.taro.md
@@ -340,7 +340,7 @@ app.use(CheckboxGroup);
     setup() {
       const group2 = ref(null) as Ref;
       const state = reactive({
-        indeterminate: true,
+        indeterminate: false,
         checkbox10: false,
         checkboxgroup5: [],
       });
@@ -356,6 +356,7 @@ app.use(CheckboxGroup);
         } else if(label.length && label.length < 4){
           state.indeterminate = true;
         } else {
+          data.indeterminate = false;
           state.checkbox10 = false;
         }
       };


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://nutui.jd.com/#/zh-CN/guide/contributing
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

close #2262

当 indeterminate 为 true 时，应该展示不确定状态的图标

而现在需要在 modelValue 为 true 且 indeterminate 为 true 时才展示。

修改为先判断 indeterminate 状态

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] NutUI 4.0 H5
- [x] NutUI 4.0 小程序
- [ ] NutUI 3.0 H5
- [ ] NutUI 3.0 小程序
- [ ] NutUI 2.0

**这个 PR 是否已自测:**

- [ ] 自测 vue3 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vue3-vue-cli)
- [ ] 自测 vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vite-ts)
- [ ] 自测 taro 脚手架使用小程序 & h5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/taro)