### PR TITLE
fix(dialog): 修复 close-on-click-overlay 失效问题

### DIFF
--- a/src/packages/__VUE/dialog/__tests__/function.spec.ts
+++ b/src/packages/__VUE/dialog/__tests__/function.spec.ts
@@ -1,8 +1,8 @@
-import DialogFunction from './dialog';
+import showDialog from './dialog';
 
 describe('function Dialog', () => {
   test('show dialog base info display ', async () => {
-    const dialog = DialogFunction({
+    const dialog = showDialog({
       title: 'title',
       content: 'content'
     });
@@ -26,7 +26,7 @@ describe('function Dialog', () => {
   });
 
   test('show dialog custom info display ', async () => {
-    const dialog = DialogFunction({
+    const dialog = showDialog({
       title: 'title',
       content: 'content'
     });
@@ -50,7 +50,7 @@ describe('function Dialog', () => {
   });
 
   test('show dialog custom footer-direction ', async () => {
-    const dialog = DialogFunction({
+    const dialog = showDialog({
       title: 'title',
       content: 'content',
       footerDirection: 'vertical'
@@ -61,7 +61,7 @@ describe('function Dialog', () => {
   });
 
   test('hide dialog footer', async () => {
-    const dialog = DialogFunction({
+    const dialog = showDialog({
       title: 'title',
       content: 'content',
       noFooter: true
@@ -73,7 +73,7 @@ describe('function Dialog', () => {
   });
 
   test('hide dialog title', async () => {
-    const dialog = DialogFunction({
+    const dialog = showDialog({
       content: 'content',
       noFooter: true
     });
@@ -83,7 +83,7 @@ describe('function Dialog', () => {
     expect(footer).toBeNull();
   });
   test('tips dialog', async () => {
-    const dialog = DialogFunction({
+    const dialog = showDialog({
       title: '温馨提示',
       content: '支持函数调用和组件调用两种方式。',
       noCancelBtn: true
@@ -95,7 +95,7 @@ describe('function Dialog', () => {
   });
 
   test('dialog cancelText okText', async () => {
-    const dialog = DialogFunction({
+    const dialog = showDialog({
       title: '温馨提示',
       content: '支持函数调用和组件调用两种方式。',
       cancelText: '取消文案自定义',
@@ -112,7 +112,7 @@ describe('function Dialog', () => {
   });
 
   test('dialog teleport', async () => {
-    const dialog = DialogFunction({
+    const dialog = showDialog({
       title: 't1',
       content: 't2',
       teleport: 'body'

--- a/src/packages/__VUE/dialog/__tests__/index.spec.ts
+++ b/src/packages/__VUE/dialog/__tests__/index.spec.ts
@@ -1,17 +1,12 @@
-import { config, mount } from '@vue/test-utils';
-import DialogTemplate from '../index.vue';
-import Overlay from '../../overlay/index.vue';
-
-beforeAll(() => {
-  config.global.components = {
-    [Overlay.name]: Overlay
-  };
-});
+import { mount } from '@vue/test-utils';
+import Dialog from '../index.vue';
+import { Overlay } from '@/packages/nutui.vue';
+import { nextTick } from 'vue';
 
 beforeEach(() => {
   // create teleport target
   const el = document.createElement('div');
-  el.id = 'app';
+  el.id = 'dialog-teleport';
   document.body.appendChild(el);
 });
 
@@ -20,36 +15,75 @@ afterEach(() => {
   document.body.outerHTML = '';
 });
 
-test('should render dialog template', async () => {
-  const wrapper = mount(DialogTemplate, {
+test('Dialog: basic props', async () => {
+  const wrapper = mount(Dialog, {
     props: {
+      visible: true,
       title: 't1',
-      content: 'c1'
+      content: 'c1',
+      cancelText: 'cancelText',
+      okText: 'okText'
     }
   });
-
-  const overLay = wrapper.getComponent(Overlay);
-  expect(await overLay.find('.nut-dialog__content'));
+  nextTick(() => {
+    const t = wrapper.find('.nut-dialog__header');
+    expect(t.html()).includes('t1');
+    const c = wrapper.find('.nut-dialog__content');
+    expect(c.html()).includes('c1');
+    const cancel = wrapper.find('.nut-dialog__footer-cancel');
+    expect(cancel.html()).includes('cancelText');
+    const ok = wrapper.find('.nut-dialog__footer-ok');
+    expect(ok.html()).includes('okText');
+  });
 });
 
-test('header slot', async () => {
-  const wrapper = mount(DialogTemplate, {
+test('Dialog: header slot', async () => {
+  const wrapper = mount(Dialog, {
     slots: {
-      header: 'test-title'
+      header: 'test title slot'
     }
   });
-
-  const overLay = wrapper.getComponent(Overlay);
-  expect(await overLay.find('.nut-dialog__header'));
+  nextTick(() => {
+    const t = wrapper.find('.nut-dialog__header');
+    expect(t.html()).includes('test title slot');
+  });
 });
 
-// test('should render dialog methods', async () => {
-// Dialog({
-//   title: '基础弹框',
-//   content: '支持函数调用和组件调用两种方式。',
-//   onCancel,
-//   onOk
+// TODO: teleport test
+// test('Dialog: teleport', async () => {
+//   const wrapper = mount(Dialog, {
+//     props: {
+//       visible: true,
+//       teleport: '#dialog-teleport'
+//     },
+//   });
+//   const overlay = wrapper.getComponent(Overlay)
+//   await overlay.get('.nut-overlay')
 // });
-// const overLay = wrapper.getComponent(Overlay);
-// expect(await overLay.find('.nut-dialog__content'))
-// });
+
+test('Dialog: closeOnClickOverlay', async () => {
+  const wrapper1 = mount(Dialog, {
+    props: {
+      visible: true
+    }
+  });
+  const wrapper2 = mount(Dialog, {
+    props: {
+      visible: true,
+      closeOnClickOverlay: false
+    }
+  });
+  const overlay1 = wrapper1.find('.nut-overlay');
+  overlay1.trigger('click');
+  nextTick(() => {
+    const popup1 = wrapper1.find('.nut-popup');
+    expect(popup1.html().includes('display: none;')).toBeTruthy();
+  });
+
+  const overlay2 = wrapper2.find('.nut-overlay');
+  overlay2.trigger('click');
+  nextTick(() => {
+    const popup2 = wrapper2.find('.nut-popup');
+    expect(popup2.html().includes('display: none;')).toBeFalsy();
+  });
+});

--- a/src/packages/__VUE/dialog/doc.en-US.md
+++ b/src/packages/__VUE/dialog/doc.en-US.md
@@ -246,7 +246,7 @@ export default {
 | title                  | Title                                                                      | string                   | -          |
 | content                | Content, support HTML                                                      | string                   | -          |
 | teleport               | Specifies a target element where Dialog will be mounted                    | string                   | `"body"`     |
-| close-on-click-overlay | Whether to close when overlay is clicked                                   | boolean                  | `false`      |
+| close-on-click-overlay | Whether to close when overlay is clicked                                   | boolean                  | `true`      |
 | no-footer              | Hide bottom button bar                                                     | boolean                  | `false`      |
 | no-ok-btn              | Hide OK button                                                             | boolean                  | `false`      |
 | no-cancel-btn          | Hide cancel button                                                         | boolean                  | `false`      |

--- a/src/packages/__VUE/dialog/doc.md
+++ b/src/packages/__VUE/dialog/doc.md
@@ -243,7 +243,7 @@ export default {
 | title                  | 标题                                                          | string                   | -          |
 | content                | 内容，支持 HTML 和组件                                        | string \| VNode          |            |
 | teleport               | 指定挂载节点                                                  | string                   | `"body"`     |
-| close-on-click-overlay | 点击蒙层是否关闭对话框                                        | boolean                  | `false`      |
+| close-on-click-overlay | 点击蒙层是否关闭对话框                                        | boolean                  | `true`      |
 | no-footer              | 是否隐藏底部按钮栏                                            | boolean                  | `false`      |
 | no-ok-btn              | 是否隐藏确定按钮                                              | boolean                  | `false`      |
 | no-cancel-btn          | 是否隐藏取消按钮                                              | boolean                  | `false`      |

--- a/src/packages/__VUE/dialog/doc.taro.md
+++ b/src/packages/__VUE/dialog/doc.taro.md
@@ -119,7 +119,7 @@ export default {
 | title                  | 标题                                                          | string                   | -          |
 | content                | 内容，支持 `HTML` 和组件                                          | string \| VNode          | -          |
 | teleport               | 指定挂载节点                                                  | string                   | `"body"`     |
-| close-on-click-overlay | 点击蒙层是否关闭对话框                                        | boolean                  | `false`      |
+| close-on-click-overlay | 点击蒙层是否关闭对话框                                        | boolean                  | `true`      |
 | no-footer              | 是否隐藏底部按钮栏                                            | boolean                  | `false`      |
 | no-ok-btn              | 是否隐藏确定按钮                                              | boolean                  | `false`      |
 | no-cancel-btn          | 是否隐藏取消按钮                                              | boolean                  | `false`      |

--- a/src/packages/__VUE/dialog/index.taro.vue
+++ b/src/packages/__VUE/dialog/index.taro.vue
@@ -2,14 +2,14 @@
   <nut-popup
     :teleport="teleport"
     v-model:visible="showPopup"
-    :close-on-click-overlay="closeOnClickOverlay"
+    :close-on-click-overlay="false"
     :lock-scroll="lockScroll"
     :pop-class="popClass"
     :overlay-class="overlayClass"
     :overlay-style="overlayStyle"
     :style="popStyle"
     round
-    @click-overlay="closed"
+    @click-overlay="onClickOverlay"
     @click-close-icon="closed"
   >
     <view :class="classes">
@@ -63,7 +63,7 @@ export default create({
     ...popupProps,
     closeOnClickOverlay: {
       type: Boolean,
-      default: false
+      default: true
     },
     title: {
       type: String,
@@ -180,8 +180,14 @@ export default create({
     };
 
     const onOk = () => {
-      closed('ok');
       emit('ok');
+      closed('ok');
+    };
+
+    const onClickOverlay = () => {
+      if (props.closeOnClickOverlay) {
+        closed('');
+      }
     };
 
     const contentStyle = computed(() => {
@@ -196,6 +202,7 @@ export default create({
       onCancel,
       onOk,
       showPopup,
+      onClickOverlay,
       contentStyle,
       translate
     };

--- a/src/packages/__VUE/dialog/index.ts
+++ b/src/packages/__VUE/dialog/index.ts
@@ -33,6 +33,7 @@ export class DialogOptions {
   noCancelBtn?: boolean = false;
   okBtnDisabled?: boolean = false;
   closeOnPopstate?: boolean = false;
+  closeOnClickOverlay?: boolean = true;
   lockScroll?: boolean = true;
 }
 

--- a/src/packages/__VUE/dialog/index.vue
+++ b/src/packages/__VUE/dialog/index.vue
@@ -2,14 +2,14 @@
   <nut-popup
     :teleport="teleport"
     v-model:visible="showPopup"
-    :close-on-click-overlay="closeOnClickOverlay"
+    :close-on-click-overlay="false"
     :lock-scroll="lockScroll"
     :pop-class="popClass"
     :overlay-class="overlayClass"
     :overlay-style="overlayStyle"
     :style="popStyle"
     round
-    @click-overlay="closed"
+    @click-overlay="onClickOverlay"
     @click-close-icon="closed"
   >
     <view :class="classes">
@@ -54,7 +54,6 @@ import { popupProps } from '../popup/props';
 import Popup from '../popup/index.vue';
 import Button from '../button/index.vue';
 export type TextAlign = 'left' | 'center' | 'right' | 'top';
-import { isPromise } from '@/packages/utils/util';
 export default create({
   inheritAttrs: false,
   components: {
@@ -65,7 +64,7 @@ export default create({
     ...popupProps,
     closeOnClickOverlay: {
       type: Boolean,
-      default: false
+      default: true
     },
     title: {
       type: String,
@@ -177,6 +176,12 @@ export default create({
       closed('ok');
     };
 
+    const onClickOverlay = () => {
+      if (props.closeOnClickOverlay) {
+        closed('');
+      }
+    };
+
     const contentStyle = computed(() => {
       return {
         textAlign: props.textAlign
@@ -189,6 +194,7 @@ export default create({
       onCancel,
       onOk,
       showPopup,
+      onClickOverlay,
       contentStyle,
       translate
     };


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://nutui.jd.com/#/zh-CN/guide/contributing
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)



**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] NutUI 4.0 H5
- [x] NutUI 4.0 小程序
- [ ] NutUI 3.0 H5
- [ ] NutUI 3.0 小程序
- [ ] NutUI 2.0

**这个 PR 是否已自测:**

- [ ] 自测 vue3 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vue3-vue-cli)
- [x] 自测 vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vite-ts)
- [x] 自测 taro 脚手架使用小程序 & h5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/taro)