### PR TITLE
feat(build): 增加了 ESM 全量构建产物

### DIFF
--- a/vite.config.build.ts
+++ b/vite.config.build.ts
@@ -36,15 +36,16 @@ export default defineConfig({
           vue: 'Vue'
         },
         exports: 'named',
-        plugins: [],
-        entryFileNames: `nutui.umd.js`
+        plugins: []
       }
     },
     lib: {
       entry: 'src/packages/nutui.vue.build.ts',
       name: 'nutui',
-      fileName: 'nutui',
-      formats: ['umd']
+      fileName: (type) => {
+        return type === 'umd' ? 'nutui.umd.js' : 'nutui.js';
+      },
+      formats: ['umd', 'es']
     }
   }
 });


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://nutui.jd.com/#/zh-CN/guide/contributing
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
`@nutui/nutui` 增加了 ESM 模块全量的 `nutui.js` 文件，可通过 CDN 方式在支持原生 ESM 模块的浏览器中进行在线调试，比如 `Vue SFC Playground`。

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 涉及以下平台:**

- [x] NutUI 4.0 H5
- [ ] NutUI 4.0 小程序
- [ ] NutUI 3.0 H5
- [ ] NutUI 3.0 小程序
- [ ] NutUI 2.0

**这个 PR 是否已自测:**

- [ ] 自测 vue3 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vue3-vue-cli)
- [x] 自测 vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vite-ts)
- [ ] 自测 taro 脚手架使用小程序 & h5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/taro)