### PR TITLE
fix: 平铺展示时 Calendar 未设置 ref

### DIFF
--- a/src/packages/__VUE/calendar/index.taro.vue
+++ b/src/packages/__VUE/calendar/index.taro.vue
@@ -52,6 +52,7 @@
     :is-auto-back-fill="isAutoBackFill"
     :poppable="poppable"
     :title="title"
+    ref="calendarRef"
     :confirm-text="confirmText"
     :start-text="startText"
     :end-text="endText"


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://nutui.jd.com/#/zh-CN/guide/contributing
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [x] 其他，请描述(Other, please describe):
     修复：Calendar平铺展示时未设置 ref 导致scrollToDate、initPosition无法使用

**这个 PR 涉及以下平台:**

- [ ] NutUI 4.0 H5
- [x] NutUI 4.0 小程序
- [ ] NutUI 3.0 H5
- [ ] NutUI 3.0 小程序
- [ ] NutUI 2.0

**这个 PR 是否已自测:**

- [x] 自测 vue3 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vue3-vue-cli)
- [x] 自测 vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/vite-ts)
- [x] 自测 taro 脚手架使用小程序 & h5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/master/taro)
