### PR TITLE
fix: taro 端组件根元素统一为 view 标签

### DIFF
--- a/src/packages/__VUE/addresslist/index.taro.vue
+++ b/src/packages/__VUE/addresslist/index.taro.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="classes">
+  <view :class="classes">
     <general-shell
       v-for="(item, index) of dataArray"
       :key="index"
@@ -33,7 +33,7 @@
     <div class="nut-address-list__bottom" v-if="showBottomButton" @click="addAddress">
       <nut-button block type="danger">{{ translate('addAddress') }}</nut-button>
     </div>
-  </div>
+  </view>
 </template>
 <script lang="ts">
 import { reactive, onMounted, ref, watch, computed } from 'vue';

--- a/src/packages/__VUE/card/index.taro.vue
+++ b/src/packages/__VUE/card/index.taro.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="nut-card">
+  <view class="nut-card">
     <div class="nut-card__left">
       <img :src="imgUrl" alt="" />
     </div>
@@ -25,7 +25,7 @@
         <slot name="footer"></slot>
       </div>
     </div>
-  </div>
+  </view>
 </template>
 
 <script lang="ts">

--- a/src/packages/__VUE/category/index.taro.vue
+++ b/src/packages/__VUE/category/index.taro.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="nut-category">
+  <view class="nut-category">
     <div class="nut-category__cateList">
       <div v-if="type == 'classify' || type == 'text'">
         <div class="nut-category__cateListLeft" v-for="(item, index) in category" :key="index">
@@ -14,7 +14,7 @@
 
       <slot></slot>
     </div>
-  </div>
+  </view>
 </template>
 <script lang="ts">
 import { PropType, ref } from 'vue';

--- a/src/packages/__VUE/categorypane/index.taro.vue
+++ b/src/packages/__VUE/categorypane/index.taro.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="nut-category-pane">
+  <view class="nut-category-pane">
     <div v-if="type == 'classify'" class="nut-category-pane__cateListRight">
       <div v-for="(item, index) in categoryChild" :key="index">
         <div class="nut-category-pane__childTitle">{{ item?.catName }}</div>
@@ -43,7 +43,7 @@
         {{ sku?.catName }}
       </div>
     </div>
-  </div>
+  </view>
 </template>
 <script lang="ts">
 import { PropType } from 'vue';

--- a/src/packages/__VUE/circleprogress/index.taro.vue
+++ b/src/packages/__VUE/circleprogress/index.taro.vue
@@ -1,12 +1,12 @@
 <template>
-  <div class="nut-circle-progress" :style="{ height: Number(radius) * 2 + 'px', width: Number(radius) * 2 + 'px' }">
+  <view class="nut-circle-progress" :style="{ height: Number(radius) * 2 + 'px', width: Number(radius) * 2 + 'px' }">
     <div :style="style"></div>
     <div class="nut-circle-progress__text">
       <slot>
         <span>{{ progress }}%</span>
       </slot>
     </div>
-  </div>
+  </view>
 </template>
 
 <script lang="ts">

--- a/src/packages/__VUE/progress/index.taro.vue
+++ b/src/packages/__VUE/progress/index.taro.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="nut-progress">
+  <view class="nut-progress">
     <div
       class="nut-progress-outer"
       :class="[showText && !textInside ? 'nut-progress-outer-part' : '', size ? 'nut-progress-' + size : '']"
@@ -41,7 +41,7 @@
         </slot>
       </template>
     </div>
-  </div>
+  </view>
 </template>
 
 <script lang="ts">

--- a/src/packages/__VUE/signature/index.taro.vue
+++ b/src/packages/__VUE/signature/index.taro.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="classes">
+  <view :class="classes">
     <div :class="['nut-signature-inner', 'spcanvas_WEAPP']">
       <canvas
         ref="spcanvas"
@@ -16,7 +16,7 @@
     </div>
     <nut-button class="nut-signature-btn" type="default" @click="clear()">{{ translate('reSign') }}</nut-button>
     <nut-button class="nut-signature-btn" type="primary" @click="confirm()">{{ translate('confirm') }}</nut-button>
-  </div>
+  </view>
 </template>
 <script lang="ts">
 import Taro from '@tarojs/taro';

--- a/src/packages/__VUE/sticky/index.taro.vue
+++ b/src/packages/__VUE/sticky/index.taro.vue
@@ -1,9 +1,9 @@
 <template>
-  <div class="nut-sticky" ref="rootRef" :style="rootStyle" :id="'rootRef-' + refRandomId">
-    <div class="nut-sticky__box" :style="stickyStyle">
+  <view class="nut-sticky" ref="rootRef" :style="rootStyle" :id="'rootRef-' + refRandomId">
+    <view class="nut-sticky__box" :style="stickyStyle">
       <slot></slot>
-    </div>
-  </div>
+    </view>
+  </view>
 </template>
 <script lang="ts">
 import { computed, ref, watch, CSSProperties, onMounted, reactive } from 'vue';

--- a/src/packages/__VUE/swipegroup/index.taro.vue
+++ b/src/packages/__VUE/swipegroup/index.taro.vue
@@ -1,7 +1,7 @@
 <template>
-  <div class="nut-swipe-group" ref="swipeGroupRef">
+  <view class="nut-swipe-group" ref="swipeGroupRef">
     <slot></slot>
-  </div>
+  </view>
 </template>
 <script lang="ts">
 import { provide, ref } from 'vue';

--- a/src/packages/__VUE/tabbar/index.taro.vue
+++ b/src/packages/__VUE/tabbar/index.taro.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="{ 'nut-tabbar__placeholder': bottom && placeholder }" :style="{ height: height + 'px' }">
+  <view :class="{ 'nut-tabbar__placeholder': bottom && placeholder }" :style="{ height: height + 'px' }">
     <view
       ref="nutTabbar"
       class="nut-tabbar"
@@ -7,7 +7,7 @@
     >
       <slot></slot>
     </view>
-  </div>
+  </view>
 </template>
 
 <script lang="ts">

--- a/src/packages/__VUE/tabbaritem/index.taro.vue
+++ b/src/packages/__VUE/tabbaritem/index.taro.vue
@@ -1,5 +1,5 @@
 <template>
-  <div
+  <view
     class="nut-tabbar-item"
     :class="{ 'nut-tabbar-item__icon--unactive': !active }"
     :style="{
@@ -28,7 +28,7 @@
         </view>
       </view>
     </nut-badge>
-  </div>
+  </view>
 </template>
 <script lang="ts">
 import { createComponent, renderIcon } from '@/packages/utils/create';


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/jdf2e/nutui/issues/1671
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

尽管 `@tarojs/plugin-html` 插件支持使用 div 编写 Taro 组件，但是 div 标签作为 Taro Vue 页面的根元素时有可能出现不可预测的问题（比如丢失插槽、ref，丢失小程序生命周期问题 #2165 #2175 ）。
因此将使用 div 作为根元素的组件统一调整为 view

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

**这个 PR 涉及以下平台:**

- [ ] NutUI 4.0 H5
- [x] NutUI 4.0 小程序
- [ ] NutUI 3.0 H5
- [ ] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [ ] 自测 Vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/nutui4-vue/vite-ts)
- [x] 自测 Taro 脚手架使用小程序 & Taro-H5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/nutui4-vue/taro)
