### PR TITLE
fix: 调整组件事件名称

### DIFF
--- a/packages/nutui-taro-demo/src/business/pages/invoice/index.vue
+++ b/packages/nutui-taro-demo/src/business/pages/invoice/index.vue
@@ -2,7 +2,7 @@
   <div class="demo full" :class="{ web: env === 'WEB' }">
     <Header v-if="env === 'WEB'" />
     <h2>默认用法</h2>
-    <nut-invoice :data="data" :formValue="formValue" @onSubmit="submit"></nut-invoice>
+    <nut-invoice :data="data" :formValue="formValue" @submit="submit"></nut-invoice>
   </div>
 </template>
 

--- a/packages/nutui-taro-demo/src/exhibition/pages/countdown/index.vue
+++ b/packages/nutui-taro-demo/src/exhibition/pages/countdown/index.vue
@@ -3,7 +3,7 @@
     <Header v-if="env === 'WEB'" />
     <h2>基础用法</h2>
     <nut-cell>
-      <nut-countdown :endTime="end" @on-end="onend"></nut-countdown>
+      <nut-countdown :endTime="end" @end="onend"></nut-countdown>
     </nut-cell>
     <h2>自定义格式</h2>
     <nut-cell>
@@ -31,7 +31,7 @@
     <h2>控制开始和暂停的倒计时</h2>
 
     <nut-cell>
-      <nut-countdown :endTime="end" :paused="paused" @on-paused="onpaused" @on-restart="onrestart" />
+      <nut-countdown :endTime="end" :paused="paused" @paused="onpaused" @restart="onrestart" />
       <div style="position: absolute; right: 10px; top: 9px">
         <nut-button type="primary" size="small" @click="toggle">{{ paused ? 'start' : 'stop' }}</nut-button>
       </div>

--- a/packages/nutui-taro-demo/src/nav/pages/navbar/index.vue
+++ b/packages/nutui-taro-demo/src/nav/pages/navbar/index.vue
@@ -3,7 +3,7 @@
     <Header v-if="env === 'WEB'" />
     <h2>基础用法</h2>
 
-    <nut-navbar @on-click-back="back" @on-click-title="title" title="订单详情">
+    <nut-navbar @click-back="back" @click-title="title" title="订单详情">
       <template #left>
         <div>返回</div>
       </template>
@@ -13,19 +13,19 @@
     </nut-navbar>
 
     <nut-navbar
-      @on-click-back="back"
-      @on-click-title="title"
-      @on-click-right="rightClick"
+      @click-back="back"
+      @click-title="title"
+      @click-right="rightClick"
       title="浏览记录"
       desc="清空"
     ></nut-navbar>
 
     <nut-navbar
       :left-show="false"
-      @on-click-back="back"
-      @on-click-title="title"
-      @on-click-icon="icon"
-      @on-click-right="rightClick"
+      @click-back="back"
+      @click-title="title"
+      @click-icon="icon"
+      @click-right="rightClick"
       title="购物车"
       :titleIcon="true"
       desc="编辑"
@@ -39,7 +39,7 @@
     </nut-navbar>
 
     <h2>自定义导航栏中间内容</h2>
-    <nut-navbar @on-click-back="back" @on-click-title="title" @on-click-right="rightClick" desc="编辑">
+    <nut-navbar @click-back="back" @click-title="title" @click-right="rightClick" desc="编辑">
       <template #content>
         <nut-tabs v-model="tab1value" @click="changeTab">
           <nut-tab-pane title="商品"> </nut-tab-pane>
@@ -53,7 +53,7 @@
     </nut-navbar>
 
     <h2>多tab切换导航</h2>
-    <nut-navbar @on-click-back="back">
+    <nut-navbar @click-back="back">
       <template #content>
         <nut-tabs v-model="tab2value" @click="changeTabList">
           <nut-tab-pane title="商品"> </nut-tab-pane>

--- a/src/packages/__VUE/countdown/__tests__/countdown.spec.ts
+++ b/src/packages/__VUE/countdown/__tests__/countdown.spec.ts
@@ -10,9 +10,9 @@ test('endTime props', async () => {
       endTime: Date.now() + 1 * 50
     }
   });
-  expect(wrapper.emitted('onEnd')).toBeFalsy();
+  expect(wrapper.emitted('end')).toBeFalsy();
   await sleep(51);
-  expect(wrapper.emitted('onEnd')).toBeTruthy();
+  expect(wrapper.emitted('end')).toBeTruthy();
 });
 
 test('format props', async () => {
@@ -63,7 +63,7 @@ test('paused props', async () => {
       'nut-button': Button
     },
     template: `
-      <nut-countdown  :endTime="endTime" :paused="paused" />
+      <nut-countdown  :end-time="endTime" :paused="paused" />
       <nut-button  @click="toggle">{{ paused ? 'start' : 'stop' }}</nut-button>
     `,
     setup() {

--- a/src/packages/__VUE/countdown/demo.vue
+++ b/src/packages/__VUE/countdown/demo.vue
@@ -2,7 +2,7 @@
   <div class="demo">
     <h2>{{ translate('basic') }}</h2>
     <nut-cell>
-      <nut-countdown :end-time="end" @on-end="onend"></nut-countdown>
+      <nut-countdown :end-time="end" @end="onend"></nut-countdown>
     </nut-cell>
     <h2>{{ translate('format') }}</h2>
     <nut-cell>
@@ -33,7 +33,7 @@
     <h2>{{ translate('controlTime') }}</h2>
 
     <nut-cell>
-      <nut-countdown :end-time="end" :paused="paused" @on-paused="onpaused" @on-restart="onrestart" />
+      <nut-countdown :end-time="end" :paused="paused" @paused="onpaused" @restart="onrestart" />
       <div style="position: absolute; right: 10px; top: 9px">
         <nut-button type="primary" size="small" @click="toggle">{{ paused ? 'start' : 'stop' }}</nut-button>
       </div>

--- a/src/packages/__VUE/countdown/doc.en-US.md
+++ b/src/packages/__VUE/countdown/doc.en-US.md
@@ -6,7 +6,7 @@ Used to display the countdown value in real time, and precision supports millise
 
 ### Install
 
-```javascript
+```js
 import { createApp } from 'vue';
 import { Countdown } from '@nutui/nutui';
 
@@ -18,25 +18,14 @@ app.use(Countdown);
 
 :::demo
 
-```html
+```vue
 <template>
-  <nut-cell>
-    <nut-countdown :end-time="end"></nut-countdown>
-  </nut-cell>
+  <nut-countdown :end-time="end"></nut-countdown>
 </template>
 
-<script>
-  import { ref, reactive, toRefs } from 'vue';
-  export default {
-    setup(props) {
-      const state = reactive({
-        end: Date.now() + 60 * 1000
-      });
-      return {
-        ...toRefs(state)
-      };
-    }
-  };
+<script setup>
+import { ref } from 'vue';
+const end = ref(Date.now() + 60 * 1000);
 </script>
 ```
 
@@ -48,24 +37,14 @@ Different countdown display text can be realized by setting the `format` attribu
 
 :::demo
 
-```html
+```vue
 <template>
-  <nut-cell>
-    <nut-countdown :endTime="end" format="DD Day HH : mm : ss" />
-  </nut-cell>
+  <nut-countdown :end-time="end" format="DD Day HH : mm : ss" />
 </template>
-<script>
-  import { ref, reactive, toRefs } from 'vue';
-  export default {
-    setup(props) {
-      const state = reactive({
-        end: Date.now() + 60 * 1000
-      });
-      return {
-        ...toRefs(state)
-      };
-    }
-  };
+
+<script setup>
+import { ref } from 'vue';
+const end = ref(Date.now() + 60 * 1000);
 </script>
 ```
 
@@ -75,24 +54,14 @@ Different countdown display text can be realized by setting the `format` attribu
 
 :::demo
 
-```html
+```vue
 <template>
-  <nut-cell>
-    <nut-countdown :endTime="end" millisecond format="HH:mm:ss:SS" />
-  </nut-cell>
+  <nut-countdown :end-time="end" millisecond format="HH:mm:ss:SS" />
 </template>
-<script>
-  import { ref, reactive, toRefs } from 'vue';
-  export default {
-    setup(props) {
-      const state = reactive({
-        end: Date.now() + 60 * 1000
-      });
-      return {
-        ...toRefs(state)
-      };
-    }
-  };
+
+<script setup>
+import { ref } from 'vue';
+const end = ref(Date.now() + 60 * 1000);
 </script>
 ```
 
@@ -102,26 +71,15 @@ Different countdown display text can be realized by setting the `format` attribu
 
 :::demo
 
-```html
+```vue
 <template>
-  <nut-cell>
-    <nut-countdown :startTime="serverTime" :endTime="end"></nut-countdown>
-  </nut-cell>
+  <nut-countdown :start-time="serverTime" :end-time="end" />
 </template>
 
-<script>
-  import { ref, reactive, toRefs } from 'vue';
-  export default {
-    setup(props) {
-      const state = reactive({
-        serverTime: Date.now() - 20 * 1000,
-        end: Date.now() + 60 * 1000
-      });
-      return {
-        ...toRefs(state)
-      };
-    }
-  };
+<script setup>
+import { ref } from 'vue';
+const serverTime = ref(Date.now() - 20 * 1000);
+const end = ref(Date.now() + 60 * 1000);
 </script>
 ```
 
@@ -131,29 +89,19 @@ Different countdown display text can be realized by setting the `format` attribu
 
 :::demo
 
-```html
+```vue
 <template>
-  <nut-cell>
-    <nut-countdown :end-time="asyncEnd"></nut-countdown>
-  </nut-cell>
+  <nut-countdown :end-time="asyncEnd" />
 </template>
 
-<script>
-  import { ref, reactive, toRefs } from 'vue';
-  export default {
-    setup(props) {
-      const state = reactive({
-        asyncEnd: 0
-      });
-      // 模拟异步时间
-      setTimeout(() => {
-        state.asyncEnd = Date.now() + 30 * 1000;
-      }, 3000);
-      return {
-        ...toRefs(state)
-      };
-    }
-  };
+<script setup>
+import { ref, onMounted } from 'vue';
+const asyncEnd = ref(0);
+onMounted(() => {
+  setTimeout(() => {
+    asyncEnd.value = Date.now() + 30 * 1000;
+  }, 3000);
+});
 </script>
 ```
 
@@ -165,41 +113,29 @@ Paused and restarted the countdown with the `paused` attribute
 
 :::demo
 
-```html
+```vue
 <template>
   <nut-cell>
-    <nut-countdown :endTime="end" :paused="paused" @on-paused="onpaused" @on-restart="onrestart" />
+    <nut-countdown :end-time="end" :paused="paused" @paused="onPaused" @restart="onRestart" />
     <div style="position:absolute;right:10px;top:9px">
       <nut-button type="primary" size="small" @click="toggle">{{ paused ? 'start' : 'stop' }}</nut-button>
     </div>
   </nut-cell>
 </template>
-<script>
-  import { ref, reactive, toRefs } from 'vue';
-  export default {
-    setup(props) {
-      const state = reactive({
-        paused: false,
-        end: Date.now() + 60 * 1000
-      });
+<script setup>
+import { ref } from 'vue';
+const paused = ref(false);
+const end = ref(Date.now() + 60 * 1000);
 
-      const toggle = () => {
-        state.paused = !state.paused;
-      };
-      const onpaused = (v) => {
-        console.log('paused: ', v);
-      };
-      const onrestart = (v) => {
-        console.log('restart: ', v);
-      };
-      return {
-        toggle,
-        onpaused,
-        onrestart,
-        ...toRefs(state)
-      };
-    }
-  };
+const toggle = () => {
+  state.paused = !state.paused;
+};
+const onPaused = (v) => {
+  console.log('paused: ', v);
+};
+const onRestart = (v) => {
+  console.log('restart: ', v);
+};
 </script>
 ```
 
@@ -209,12 +145,12 @@ Paused and restarted the countdown with the `paused` attribute
 
 :::demo
 
-```html
+```vue
 <template>
   <nut-cell>
-    <nut-countdown v-model="resetTime" :endTime="end">
+    <nut-countdown v-model="resetTime" :end-time="end">
       <div class="countdown-part-box">
-        <div class="part-item-symbol">{{ resetTime.d }}Day</div>
+        <div class="part-item-symbol">{{ resetTime.d }}天</div>
         <div class="part-item h">{{ resetTime.h }}</div>
         <span class="part-item-symbol">:</span>
         <div class="part-item m">{{ resetTime.m }}</div>
@@ -224,46 +160,37 @@ Paused and restarted the countdown with the `paused` attribute
     </nut-countdown>
   </nut-cell>
 </template>
-<script>
-  import { ref, reactive, toRefs } from 'vue';
-  export default {
-    setup(props) {
-      const state = reactive({
-        end: Date.now() + 60 * 1000,
-        resetTime: {
-          d: '1',
-          h: '00',
-          m: '00',
-          s: '00'
-        }
-      });
-      return {
-        ...toRefs(state)
-      };
-    }
-  };
+<script setup>
+import { ref, reactive } from 'vue';
+const end = ref(Date.now() + 60 * 1000);
+const resetTime = reactive({
+  d: '1',
+  h: '00',
+  m: '00',
+  s: '00'
+});
 </script>
 <style>
-  .countdown-part-box {
-    display: flex;
-    align-items: center;
-  }
-  .part-item {
-    flex-shrink: 0;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 20px;
-    height: 25px;
-    background: #e8220e;
-    color: #fff;
-    font-size: 14px;
-    border-radius: 6px;
-  }
+.countdown-part-box {
+  display: flex;
+  align-items: center;
+}
+.part-item {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 25px;
+  background: #e8220e;
+  color: #fff;
+  font-size: 14px;
+  border-radius: 6px;
+}
 
-  .part-item-symbol {
-    margin: 0 5px;
-  }
+.part-item-symbol {
+  margin: 0 5px;
+}
 </style>
 ```
 
@@ -273,34 +200,29 @@ Paused and restarted the countdown with the `paused` attribute
 
 :::demo
 
-```html
+```vue
 <template>
   <nut-cell>
-    <nut-countdown time="20000" ref="Countdown" :autoStart="false" format="ss:SS" />
+    <nut-countdown time="20000" ref="Countdown" :auto-start="false" format="ss:SS" />
   </nut-cell>
   <nut-grid :column-num="3">
-    <nut-grid-item><nut-button type="primary" @click="start">Start</nut-button></nut-grid-item>
-    <nut-grid-item><nut-button type="primary" @click="pause">Pause</nut-button></nut-grid-item>
-    <nut-grid-item><nut-button type="primary" @click="reset">Reset</nut-button></nut-grid-item>
+    <nut-grid-item><nut-button type="primary" @click="start">开始</nut-button></nut-grid-item>
+    <nut-grid-item><nut-button type="primary" @click="pause">暂停</nut-button></nut-grid-item>
+    <nut-grid-item><nut-button type="primary" @click="reset">重置</nut-button></nut-grid-item>
   </nut-grid>
 </template>
-<script>
-  import { ref, reactive, toRefs } from 'vue';
-  export default {
-    setup(props) {
-      const Countdown = ref(null);
-      const start = () => {
-        Countdown.value.start();
-      };
-      const pause = () => {
-        Countdown.value.pause();
-      };
-      const reset = () => {
-        Countdown.value.reset();
-      };
-      return { Countdown, start, pause, reset };
-    }
-  };
+<script setup>
+import { ref } from 'vue';
+const Countdown = ref(null);
+const start = () => {
+  Countdown.value.start();
+};
+const pause = () => {
+  Countdown.value.pause();
+};
+const reset = () => {
+  Countdown.value.reset();
+};
 </script>
 ```
 
@@ -337,11 +259,14 @@ Paused and restarted the countdown with the `paused` attribute
 
 ### Events
 
-| Event      | Description                     | Arguments          |
-| ---------- | ------------------------------- | ------------------ |
-| on-end     | Emitted when count down end     | Residual Timestamp |
-| on-paused  | Emitted when count down paused  | Residual Timestamp |
-| on-restart | Emitted when count down restart | Residual Timestamp |
+| Event           | Description                     | Arguments          |
+| --------------- | ------------------------------- | ------------------ |
+| end`v4.1.5`     | Emitted when count down end     | Residual Timestamp |
+| paused`v4.1.5`  | Emitted when count down paused  | Residual Timestamp |
+| restart`v4.1.5` | Emitted when count down restart | Residual Timestamp |
+| on-end          | Emitted when count down end     | Residual Timestamp |
+| on-paused       | Emitted when count down paused  | Residual Timestamp |
+| on-restart      | Emitted when count down restart | Residual Timestamp |
 
 ### Methods
 

--- a/src/packages/__VUE/countdown/doc.md
+++ b/src/packages/__VUE/countdown/doc.md
@@ -6,7 +6,7 @@
 
 ### 安装
 
-```javascript
+```js
 import { createApp } from 'vue';
 import { Countdown } from '@nutui/nutui';
 
@@ -18,25 +18,14 @@ app.use(Countdown);
 
 :::demo
 
-```html
+```vue
 <template>
-  <nut-cell>
-    <nut-countdown :end-time="end"></nut-countdown>
-  </nut-cell>
+  <nut-countdown :end-time="end"></nut-countdown>
 </template>
 
-<script>
-  import { ref, reactive, toRefs } from 'vue';
-  export default {
-    setup(props) {
-      const state = reactive({
-        end: Date.now() + 60 * 1000
-      });
-      return {
-        ...toRefs(state)
-      };
-    }
-  };
+<script setup>
+import { ref } from 'vue';
+const end = ref(Date.now() + 60 * 1000);
 </script>
 ```
 
@@ -48,24 +37,14 @@ app.use(Countdown);
 
 :::demo
 
-```html
+```vue
 <template>
-  <nut-cell>
-    <nut-countdown :endTime="end" format="DD 天 HH 时 mm 分 ss 秒" />
-  </nut-cell>
+  <nut-countdown :end-time="end" format="DD 天 HH 时 mm 分 ss 秒" />
 </template>
-<script>
-  import { ref, reactive, toRefs } from 'vue';
-  export default {
-    setup(props) {
-      const state = reactive({
-        end: Date.now() + 60 * 1000
-      });
-      return {
-        ...toRefs(state)
-      };
-    }
-  };
+
+<script setup>
+import { ref } from 'vue';
+const end = ref(Date.now() + 60 * 1000);
 </script>
 ```
 
@@ -75,24 +54,14 @@ app.use(Countdown);
 
 :::demo
 
-```html
+```vue
 <template>
-  <nut-cell>
-    <nut-countdown :endTime="end" millisecond format="HH:mm:ss:SS" />
-  </nut-cell>
+  <nut-countdown :end-time="end" millisecond format="HH:mm:ss:SS" />
 </template>
-<script>
-  import { ref, reactive, toRefs } from 'vue';
-  export default {
-    setup(props) {
-      const state = reactive({
-        end: Date.now() + 60 * 1000
-      });
-      return {
-        ...toRefs(state)
-      };
-    }
-  };
+
+<script setup>
+import { ref } from 'vue';
+const end = ref(Date.now() + 60 * 1000);
 </script>
 ```
 
@@ -102,26 +71,15 @@ app.use(Countdown);
 
 :::demo
 
-```html
+```vue
 <template>
-  <nut-cell>
-    <nut-countdown :startTime="serverTime" :endTime="end"></nut-countdown>
-  </nut-cell>
+  <nut-countdown :start-time="serverTime" :end-time="end" />
 </template>
 
-<script>
-  import { ref, reactive, toRefs } from 'vue';
-  export default {
-    setup(props) {
-      const state = reactive({
-        serverTime: Date.now() - 20 * 1000,
-        end: Date.now() + 60 * 1000
-      });
-      return {
-        ...toRefs(state)
-      };
-    }
-  };
+<script setup>
+import { ref } from 'vue';
+const serverTime = ref(Date.now() - 20 * 1000);
+const end = ref(Date.now() + 60 * 1000);
 </script>
 ```
 
@@ -131,29 +89,19 @@ app.use(Countdown);
 
 :::demo
 
-```html
+```vue
 <template>
-  <nut-cell>
-    <nut-countdown :end-time="asyncEnd"></nut-countdown>
-  </nut-cell>
+  <nut-countdown :end-time="asyncEnd" />
 </template>
 
-<script>
-  import { ref, reactive, toRefs } from 'vue';
-  export default {
-    setup(props) {
-      const state = reactive({
-        asyncEnd: 0
-      });
-      // 模拟异步时间
-      setTimeout(() => {
-        state.asyncEnd = Date.now() + 30 * 1000;
-      }, 3000);
-      return {
-        ...toRefs(state)
-      };
-    }
-  };
+<script setup>
+import { ref, onMounted } from 'vue';
+const asyncEnd = ref(0);
+onMounted(() => {
+  setTimeout(() => {
+    asyncEnd.value = Date.now() + 30 * 1000;
+  }, 3000);
+});
 </script>
 ```
 
@@ -165,41 +113,29 @@ app.use(Countdown);
 
 :::demo
 
-```html
+```vue
 <template>
   <nut-cell>
-    <nut-countdown :endTime="end" :paused="paused" @on-paused="onpaused" @on-restart="onrestart" />
+    <nut-countdown :end-time="end" :paused="paused" @paused="onPaused" @restart="onRestart" />
     <div style="position:absolute;right:10px;top:9px">
       <nut-button type="primary" size="small" @click="toggle">{{ paused ? 'start' : 'stop' }}</nut-button>
     </div>
   </nut-cell>
 </template>
-<script>
-  import { ref, reactive, toRefs } from 'vue';
-  export default {
-    setup(props) {
-      const state = reactive({
-        paused: false,
-        end: Date.now() + 60 * 1000
-      });
+<script setup>
+import { ref } from 'vue';
+const paused = ref(false);
+const end = ref(Date.now() + 60 * 1000);
 
-      const toggle = () => {
-        state.paused = !state.paused;
-      };
-      const onpaused = (v) => {
-        console.log('paused: ', v);
-      };
-      const onrestart = (v) => {
-        console.log('restart: ', v);
-      };
-      return {
-        toggle,
-        onpaused,
-        onrestart,
-        ...toRefs(state)
-      };
-    }
-  };
+const toggle = () => {
+  state.paused = !state.paused;
+};
+const onPaused = (v) => {
+  console.log('paused: ', v);
+};
+const onRestart = (v) => {
+  console.log('restart: ', v);
+};
 </script>
 ```
 
@@ -209,10 +145,10 @@ app.use(Countdown);
 
 :::demo
 
-```html
+```vue
 <template>
   <nut-cell>
-    <nut-countdown v-model="resetTime" :endTime="end">
+    <nut-countdown v-model="resetTime" :end-time="end">
       <div class="countdown-part-box">
         <div class="part-item-symbol">{{ resetTime.d }}天</div>
         <div class="part-item h">{{ resetTime.h }}</div>
@@ -224,46 +160,37 @@ app.use(Countdown);
     </nut-countdown>
   </nut-cell>
 </template>
-<script>
-  import { ref, reactive, toRefs } from 'vue';
-  export default {
-    setup(props) {
-      const state = reactive({
-        end: Date.now() + 60 * 1000,
-        resetTime: {
-          d: '1',
-          h: '00',
-          m: '00',
-          s: '00'
-        }
-      });
-      return {
-        ...toRefs(state)
-      };
-    }
-  };
+<script setup>
+import { ref, reactive } from 'vue';
+const end = ref(Date.now() + 60 * 1000);
+const resetTime = reactive({
+  d: '1',
+  h: '00',
+  m: '00',
+  s: '00'
+});
 </script>
 <style>
-  .countdown-part-box {
-    display: flex;
-    align-items: center;
-  }
-  .part-item {
-    flex-shrink: 0;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 20px;
-    height: 25px;
-    background: #e8220e;
-    color: #fff;
-    font-size: 14px;
-    border-radius: 6px;
-  }
+.countdown-part-box {
+  display: flex;
+  align-items: center;
+}
+.part-item {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 25px;
+  background: #e8220e;
+  color: #fff;
+  font-size: 14px;
+  border-radius: 6px;
+}
 
-  .part-item-symbol {
-    margin: 0 5px;
-  }
+.part-item-symbol {
+  margin: 0 5px;
+}
 </style>
 ```
 
@@ -271,14 +198,14 @@ app.use(Countdown);
 
 ### 手动控制
 
-通过 `ref` 获取到组件实例后，可以调用 `start`、`pause`、`reset` 方法。在使用手动控制时，通过 `time` 属性实现倒计时总时长，单位为毫秒。`startTime`、`endTime` 属性失效
+通过 `ref` 获取到组件实例后，可以调用 `start`、`pause`、`reset` 方法。在使用手动控制时，通过 `time` 属性实现倒计时总时长，单位为毫秒。`start-time`、`end-time` 属性失效
 
 :::demo
 
-```html
+```vue
 <template>
   <nut-cell>
-    <nut-countdown time="20000" ref="Countdown" :autoStart="false" format="ss:SS" />
+    <nut-countdown time="20000" ref="Countdown" :auto-start="false" format="ss:SS" />
   </nut-cell>
   <nut-grid :column-num="3">
     <nut-grid-item><nut-button type="primary" @click="start">开始</nut-button></nut-grid-item>
@@ -286,23 +213,18 @@ app.use(Countdown);
     <nut-grid-item><nut-button type="primary" @click="reset">重置</nut-button></nut-grid-item>
   </nut-grid>
 </template>
-<script>
-  import { ref, reactive, toRefs } from 'vue';
-  export default {
-    setup(props) {
-      const Countdown = ref(null);
-      const start = () => {
-        Countdown.value.start();
-      };
-      const pause = () => {
-        Countdown.value.pause();
-      };
-      const reset = () => {
-        Countdown.value.reset();
-      };
-      return { Countdown, start, pause, reset };
-    }
-  };
+<script setup>
+import { ref } from 'vue';
+const Countdown = ref(null);
+const start = () => {
+  Countdown.value.start();
+};
+const pause = () => {
+  Countdown.value.pause();
+};
+const reset = () => {
+  Countdown.value.reset();
+};
 </script>
 ```
 
@@ -312,16 +234,16 @@ app.use(Countdown);
 
 ### Props
 
-| 参数        | 说明                                                      | 类型             | 默认值       |
-| ----------- | --------------------------------------------------------- | ---------------- | ------------ |
-| v-model     | 当前时间，自定义展示内容时生效                            | object           | `{}`         |
-| start-time  | 开始时间                                                  | string \| number | `Date.now()` |
-| end-time    | 结束时间                                                  | string \| number | `Date.now()` |
-| format      | 时间格式                                                  | string           | `HH:mm:ss`   |
-| millisecond | 是否开启毫秒级渲染                                        | boolean          | `false`      |
-| auto-start  | 是否自动开始倒计时                                        | boolean          | `true`       |
-| time        | 倒计时显示时间，单位是毫秒。`autoStart` 为 `false` 时生效 | string \| number | `0`          |
-| paused      | 是否暂停                                                  | boolean          | `false`      |
+| 参数        | 说明                                                       | 类型             | 默认值       |
+| ----------- | ---------------------------------------------------------- | ---------------- | ------------ |
+| v-model     | 当前时间，自定义展示内容时生效                             | object           | `{}`         |
+| start-time  | 开始时间                                                   | string \| number | `Date.now()` |
+| end-time    | 结束时间                                                   | string \| number | `Date.now()` |
+| format      | 时间格式                                                   | string           | `HH:mm:ss`   |
+| millisecond | 是否开启毫秒级渲染                                         | boolean          | `false`      |
+| auto-start  | 是否自动开始倒计时                                         | boolean          | `true`       |
+| time        | 倒计时显示时间，单位是毫秒。`auto-start` 为 `false` 时生效 | string \| number | `0`          |
+| paused      | 是否暂停                                                   | boolean          | `false`      |
 
 ### format 格式
 
@@ -337,11 +259,14 @@ app.use(Countdown);
 
 ### Events
 
-| 事件名     | 说明         | 回调参数   |
-| ---------- | ------------ | ---------- |
-| on-end     | 倒计时结束时 | 剩余时间戳 |
-| on-paused  | 暂停时       | 剩余时间戳 |
-| on-restart | 暂停时       | 剩余时间戳 |
+| 事件名          | 说明         | 回调参数   |
+| --------------- | ------------ | ---------- |
+| end`v4.1.5`     | 倒计时结束时 | 剩余时间戳 |
+| paused`v4.1.5`  | 暂停时       | 剩余时间戳 |
+| restart`v4.1.5` | 暂停时       | 剩余时间戳 |
+| on-end          | 倒计时结束时 | 剩余时间戳 |
+| on-paused       | 暂停时       | 剩余时间戳 |
+| on-restart      | 暂停时       | 剩余时间戳 |
 
 ### Methods
 

--- a/src/packages/__VUE/countdown/doc.taro.md
+++ b/src/packages/__VUE/countdown/doc.taro.md
@@ -6,7 +6,7 @@
 
 ### 安装
 
-```javascript
+```js
 import { createApp } from 'vue';
 import { Countdown } from '@nutui/nutui-taro';
 
@@ -18,25 +18,14 @@ app.use(Countdown);
 
 :::demo
 
-```html
+```vue
 <template>
-  <nut-cell>
-    <nut-countdown :end-time="end"></nut-countdown>
-  </nut-cell>
+  <nut-countdown :end-time="end"></nut-countdown>
 </template>
 
-<script>
-  import { ref, reactive, toRefs } from 'vue';
-  export default {
-    setup(props) {
-      const state = reactive({
-        end: Date.now() + 60 * 1000
-      });
-      return {
-        ...toRefs(state)
-      };
-    }
-  };
+<script setup>
+import { ref } from 'vue';
+const end = ref(Date.now() + 60 * 1000);
 </script>
 ```
 
@@ -48,24 +37,14 @@ app.use(Countdown);
 
 :::demo
 
-```html
+```vue
 <template>
-  <nut-cell>
-    <nut-countdown :endTime="end" format="DD 天 HH 时 mm 分 ss 秒" />
-  </nut-cell>
+  <nut-countdown :end-time="end" format="DD 天 HH 时 mm 分 ss 秒" />
 </template>
-<script>
-  import { ref, reactive, toRefs } from 'vue';
-  export default {
-    setup(props) {
-      const state = reactive({
-        end: Date.now() + 60 * 1000
-      });
-      return {
-        ...toRefs(state)
-      };
-    }
-  };
+
+<script setup>
+import { ref } from 'vue';
+const end = ref(Date.now() + 60 * 1000);
 </script>
 ```
 
@@ -75,24 +54,14 @@ app.use(Countdown);
 
 :::demo
 
-```html
+```vue
 <template>
-  <nut-cell>
-    <nut-countdown :endTime="end" millisecond format="HH:mm:ss:SS" />
-  </nut-cell>
+  <nut-countdown :end-time="end" millisecond format="HH:mm:ss:SS" />
 </template>
-<script>
-  import { ref, reactive, toRefs } from 'vue';
-  export default {
-    setup(props) {
-      const state = reactive({
-        end: Date.now() + 60 * 1000
-      });
-      return {
-        ...toRefs(state)
-      };
-    }
-  };
+
+<script setup>
+import { ref } from 'vue';
+const end = ref(Date.now() + 60 * 1000);
 </script>
 ```
 
@@ -102,26 +71,15 @@ app.use(Countdown);
 
 :::demo
 
-```html
+```vue
 <template>
-  <nut-cell>
-    <nut-countdown :startTime="serverTime" :endTime="end"></nut-countdown>
-  </nut-cell>
+  <nut-countdown :start-time="serverTime" :end-time="end" />
 </template>
 
-<script>
-  import { ref, reactive, toRefs } from 'vue';
-  export default {
-    setup(props) {
-      const state = reactive({
-        serverTime: Date.now() - 20 * 1000,
-        end: Date.now() + 60 * 1000
-      });
-      return {
-        ...toRefs(state)
-      };
-    }
-  };
+<script setup>
+import { ref } from 'vue';
+const serverTime = ref(Date.now() - 20 * 1000);
+const end = ref(Date.now() + 60 * 1000);
 </script>
 ```
 
@@ -131,29 +89,19 @@ app.use(Countdown);
 
 :::demo
 
-```html
+```vue
 <template>
-  <nut-cell>
-    <nut-countdown :end-time="asyncEnd"></nut-countdown>
-  </nut-cell>
+  <nut-countdown :end-time="asyncEnd" />
 </template>
 
-<script>
-  import { ref, reactive, toRefs } from 'vue';
-  export default {
-    setup(props) {
-      const state = reactive({
-        asyncEnd: 0
-      });
-      // 模拟异步时间
-      setTimeout(() => {
-        state.asyncEnd = Date.now() + 30 * 1000;
-      }, 3000);
-      return {
-        ...toRefs(state)
-      };
-    }
-  };
+<script setup>
+import { ref, onMounted } from 'vue';
+const asyncEnd = ref(0);
+onMounted(() => {
+  setTimeout(() => {
+    asyncEnd.value = Date.now() + 30 * 1000;
+  }, 3000);
+});
 </script>
 ```
 
@@ -165,41 +113,29 @@ app.use(Countdown);
 
 :::demo
 
-```html
+```vue
 <template>
   <nut-cell>
-    <nut-countdown :endTime="end" :paused="paused" @on-paused="onpaused" @on-restart="onrestart" />
+    <nut-countdown :end-time="end" :paused="paused" @paused="onPaused" @restart="onRestart" />
     <div style="position:absolute;right:10px;top:9px">
       <nut-button type="primary" size="small" @click="toggle">{{ paused ? 'start' : 'stop' }}</nut-button>
     </div>
   </nut-cell>
 </template>
-<script>
-  import { ref, reactive, toRefs } from 'vue';
-  export default {
-    setup(props) {
-      const state = reactive({
-        paused: false,
-        end: Date.now() + 60 * 1000
-      });
+<script setup>
+import { ref } from 'vue';
+const paused = ref(false);
+const end = ref(Date.now() + 60 * 1000);
 
-      const toggle = () => {
-        state.paused = !state.paused;
-      };
-      const onpaused = (v) => {
-        console.log('paused: ', v);
-      };
-      const onrestart = (v) => {
-        console.log('restart: ', v);
-      };
-      return {
-        toggle,
-        onpaused,
-        onrestart,
-        ...toRefs(state)
-      };
-    }
-  };
+const toggle = () => {
+  state.paused = !state.paused;
+};
+const onPaused = (v) => {
+  console.log('paused: ', v);
+};
+const onRestart = (v) => {
+  console.log('restart: ', v);
+};
 </script>
 ```
 
@@ -209,10 +145,10 @@ app.use(Countdown);
 
 :::demo
 
-```html
+```vue
 <template>
   <nut-cell>
-    <nut-countdown v-model="resetTime" :endTime="end">
+    <nut-countdown v-model="resetTime" :end-time="end">
       <div class="countdown-part-box">
         <div class="part-item-symbol">{{ resetTime.d }}天</div>
         <div class="part-item h">{{ resetTime.h }}</div>
@@ -224,46 +160,37 @@ app.use(Countdown);
     </nut-countdown>
   </nut-cell>
 </template>
-<script>
-  import { ref, reactive, toRefs } from 'vue';
-  export default {
-    setup(props) {
-      const state = reactive({
-        end: Date.now() + 60 * 1000,
-        resetTime: {
-          d: '1',
-          h: '00',
-          m: '00',
-          s: '00'
-        }
-      });
-      return {
-        ...toRefs(state)
-      };
-    }
-  };
+<script setup>
+import { ref, reactive } from 'vue';
+const end = ref(Date.now() + 60 * 1000);
+const resetTime = reactive({
+  d: '1',
+  h: '00',
+  m: '00',
+  s: '00'
+});
 </script>
 <style>
-  .countdown-part-box {
-    display: flex;
-    align-items: center;
-  }
-  .part-item {
-    flex-shrink: 0;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 20px;
-    height: 25px;
-    background: #e8220e;
-    color: #fff;
-    font-size: 14px;
-    border-radius: 6px;
-  }
+.countdown-part-box {
+  display: flex;
+  align-items: center;
+}
+.part-item {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 25px;
+  background: #e8220e;
+  color: #fff;
+  font-size: 14px;
+  border-radius: 6px;
+}
 
-  .part-item-symbol {
-    margin: 0 5px;
-  }
+.part-item-symbol {
+  margin: 0 5px;
+}
 </style>
 ```
 
@@ -271,14 +198,14 @@ app.use(Countdown);
 
 ### 手动控制
 
-通过 `ref` 获取到组件实例后，可以调用 `start`、`pause`、`reset` 方法。在使用手动控制时，通过 `time` 属性实现倒计时总时长，单位为毫秒。`startTime`、`endTime` 属性失效
+通过 `ref` 获取到组件实例后，可以调用 `start`、`pause`、`reset` 方法。在使用手动控制时，通过 `time` 属性实现倒计时总时长，单位为毫秒。`start-time`、`end-time` 属性失效
 
 :::demo
 
-```html
+```vue
 <template>
   <nut-cell>
-    <nut-countdown time="20000" ref="Countdown" :autoStart="false" format="ss:SS" />
+    <nut-countdown time="20000" ref="Countdown" :auto-start="false" format="ss:SS" />
   </nut-cell>
   <nut-grid :column-num="3">
     <nut-grid-item><nut-button type="primary" @click="start">开始</nut-button></nut-grid-item>
@@ -286,23 +213,18 @@ app.use(Countdown);
     <nut-grid-item><nut-button type="primary" @click="reset">重置</nut-button></nut-grid-item>
   </nut-grid>
 </template>
-<script>
-  import { ref, reactive, toRefs } from 'vue';
-  export default {
-    setup(props) {
-      const Countdown = ref(null);
-      const start = () => {
-        Countdown.value.start();
-      };
-      const pause = () => {
-        Countdown.value.pause();
-      };
-      const reset = () => {
-        Countdown.value.reset();
-      };
-      return { Countdown, start, pause, reset };
-    }
-  };
+<script setup>
+import { ref } from 'vue';
+const Countdown = ref(null);
+const start = () => {
+  Countdown.value.start();
+};
+const pause = () => {
+  Countdown.value.pause();
+};
+const reset = () => {
+  Countdown.value.reset();
+};
 </script>
 ```
 
@@ -312,16 +234,16 @@ app.use(Countdown);
 
 ### Props
 
-| 参数        | 说明                                                      | 类型             | 默认值       |
-| ----------- | --------------------------------------------------------- | ---------------- | ------------ |
-| v-model     | 当前时间，自定义展示内容时生效                            | object           | `{}`         |
-| start-time  | 开始时间                                                  | string \| number | `Date.now()` |
-| end-time    | 结束时间                                                  | string \| number | `Date.now()` |
-| format      | 时间格式                                                  | string           | `HH:mm:ss`   |
-| millisecond | 是否开启毫秒级渲染                                        | boolean          | `false`      |
-| auto-start  | 是否自动开始倒计时                                        | boolean          | `true`       |
-| time        | 倒计时显示时间，单位是毫秒。`autoStart` 为 `false` 时生效 | string \| number | `0`          |
-| paused      | 是否暂停                                                  | boolean          | `false`      |
+| 参数        | 说明                                                       | 类型             | 默认值       |
+| ----------- | ---------------------------------------------------------- | ---------------- | ------------ |
+| v-model     | 当前时间，自定义展示内容时生效                             | object           | `{}`         |
+| start-time  | 开始时间                                                   | string \| number | `Date.now()` |
+| end-time    | 结束时间                                                   | string \| number | `Date.now()` |
+| format      | 时间格式                                                   | string           | `HH:mm:ss`   |
+| millisecond | 是否开启毫秒级渲染                                         | boolean          | `false`      |
+| auto-start  | 是否自动开始倒计时                                         | boolean          | `true`       |
+| time        | 倒计时显示时间，单位是毫秒。`auto-start` 为 `false` 时生效 | string \| number | `0`          |
+| paused      | 是否暂停                                                   | boolean          | `false`      |
 
 ### format 格式
 
@@ -337,21 +259,24 @@ app.use(Countdown);
 
 ### Events
 
-| 事件名     | 说明         | 回调参数   |
-| ---------- | ------------ | ---------- |
-| on-end     | 倒计时结束时 | 剩余时间戳 |
-| on-paused  | 暂停时       | 剩余时间戳 |
-| on-restart | 暂停时       | 剩余时间戳 |
+| 事件名          | 说明         | 回调参数   |
+| --------------- | ------------ | ---------- |
+| end`v4.1.5`     | 倒计时结束时 | 剩余时间戳 |
+| paused`v4.1.5`  | 暂停时       | 剩余时间戳 |
+| restart`v4.1.5` | 暂停时       | 剩余时间戳 |
+| on-end          | 倒计时结束时 | 剩余时间戳 |
+| on-paused       | 暂停时       | 剩余时间戳 |
+| on-restart      | 暂停时       | 剩余时间戳 |
 
 ### Methods
 
 通过 `ref` 可以获取到 `Countdown` 实例并调用实例方法。
 
-| 方法名 | 说明                                                          |
-| ------ | ------------------------------------------------------------- |
-| start  | 开始倒计时                                                    |
-| pause  | 暂停倒计时                                                    |
-| reset  | 重设倒计时，若 `auto-start` 为 `true`，重设后会自动开始倒计时 |
+| 方法名 | 说明                                                         |
+| ------ | ------------------------------------------------------------ |
+| start  | 开始倒计时                                                   |
+| pause  | 暂停倒计时                                                   |
+| reset  | 重设倒计时，若 `auto-start`为 `true`，重设后会自动开始倒计时 |
 
 ## 主题定制
 

--- a/src/packages/__VUE/countdown/index.taro.vue
+++ b/src/packages/__VUE/countdown/index.taro.vue
@@ -14,7 +14,6 @@ import { createComponent } from '@/packages/utils/create';
 import { getTimeStamp } from './util';
 import { padZero } from '@/packages/utils/util';
 const { componentName, create, translate } = createComponent('countdown');
-
 export default create({
   props: {
     modelValue: {
@@ -64,7 +63,17 @@ export default create({
       default: 0
     }
   },
-  emits: ['input', 'onEnd', 'onRestart', 'onPaused', 'update:modelValue'],
+  emits: [
+    'input',
+    'update:modelValue',
+    'end',
+    'restart',
+    'paused',
+    // will be deprecated
+    'onEnd',
+    'onRestart',
+    'onPaused'
+  ],
 
   setup(props: any, { emit, slots }) {
     const state = reactive({
@@ -106,6 +115,7 @@ export default create({
             if (!remainTime) {
               state.counting = false;
               pause();
+              emit('end');
               emit('onEnd');
             }
 
@@ -192,6 +202,7 @@ export default create({
         state.counting = true;
         state.handleEndTime = Date.now() + Number(state.restTime);
         tick();
+        emit('restart', state.restTime);
         emit('onRestart', state.restTime);
       }
     };
@@ -199,6 +210,7 @@ export default create({
     const pause = () => {
       cancelAnimationFrame(state.timer as any);
       state.counting = false;
+      emit('paused', state.restTime);
       emit('onPaused', state.restTime);
     };
 
@@ -240,6 +252,7 @@ export default create({
             state.handleEndTime = Date.now() + Number(state.restTime);
             tick();
           }
+          emit('restart', state.restTime);
           emit('onRestart', state.restTime);
         }
       }

--- a/src/packages/__VUE/countdown/index.vue
+++ b/src/packages/__VUE/countdown/index.vue
@@ -63,7 +63,17 @@ export default create({
       default: 0
     }
   },
-  emits: ['input', 'onEnd', 'onRestart', 'onPaused', 'update:modelValue'],
+  emits: [
+    'input',
+    'update:modelValue',
+    'end',
+    'restart',
+    'paused',
+    // will be deprecated
+    'onEnd',
+    'onRestart',
+    'onPaused'
+  ],
 
   setup(props: any, { emit, slots }) {
     const state = reactive({
@@ -105,6 +115,7 @@ export default create({
             if (!remainTime) {
               state.counting = false;
               pause();
+              emit('end');
               emit('onEnd');
             }
 
@@ -191,6 +202,7 @@ export default create({
         state.counting = true;
         state.handleEndTime = Date.now() + Number(state.restTime);
         tick();
+        emit('restart', state.restTime);
         emit('onRestart', state.restTime);
       }
     };
@@ -198,6 +210,7 @@ export default create({
     const pause = () => {
       cancelAnimationFrame(state.timer as any);
       state.counting = false;
+      emit('paused', state.restTime);
       emit('onPaused', state.restTime);
     };
 
@@ -239,6 +252,7 @@ export default create({
             state.handleEndTime = Date.now() + Number(state.restTime);
             tick();
           }
+          emit('restart', state.restTime);
           emit('onRestart', state.restTime);
         }
       }

--- a/src/packages/__VUE/invoice/demo.vue
+++ b/src/packages/__VUE/invoice/demo.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="demo full">
     <h2>{{ translate('basic') }}</h2>
-    <nut-invoice :data="data" :form-value="formValue" @on-submit="submit"></nut-invoice>
+    <nut-invoice :data="data" :form-value="formValue" @submit="submit"></nut-invoice>
   </div>
 </template>
 

--- a/src/packages/__VUE/invoice/doc.en-US.md
+++ b/src/packages/__VUE/invoice/doc.en-US.md
@@ -20,108 +20,93 @@ app.use(Invoice);
 
 ```html
 <template>
-  <nut-invoice :data="data" :formValue="formValue" @onSubmit="submit"> </nut-invoice>
+  <nut-invoice :data="data" :form-value="formValue" @submit="submit"></nut-invoice>
 </template>
-<script lang="ts">
+<script setup>
   import { ref, reactive } from 'vue';
-  import { showToast } from '@nutui/nutui';
-  import '@nutui/nutui/dist/packages/toast/style';
-  export default {
-    setup() {
-      // Promise 异步校验
-      const asyncValidator = (val: string) => {
-        return new Promise((resolve) => {
-          showToast.loading('模拟异步验证中...');
-          setTimeout(() => {
-            showToast.hide();
-            resolve(/^400(-?)[0-9]{7}$|^1\d{10}$|^0[0-9]{2,3}-[0-9]{7,8}$/.test(val));
-          }, 1000);
-        });
-      };
+  // Promise 异步校验
+  const asyncValidator = (val: string) => {
+    return new Promise((resolve) => {
+      console.log('模拟异步验证中...');
+      setTimeout(() => {
+        resolve(/^400(-?)[0-9]{7}$|^1\d{10}$|^0[0-9]{2,3}-[0-9]{7,8}$/.test(val));
+      }, 1000);
+    });
+  };
 
-      let data: any = ref([
+  const data: any = ref([
+    {
+      type: 'radio',
+      label: '发票类型',
+      radioLabel: [
         {
-          type: 'radio',
-          label: '发票类型',
-
-          radioLabel: [
-            {
-              label: '企业'
-            },
-            {
-              label: '个人或事业单位'
-            }
-          ],
-          formItemProp: 'type',
-          required: true
+          label: '企业'
         },
         {
-          label: '发票抬头',
-          placeholder: '请输入发票抬头',
-          formItemProp: 'name',
-          rules: [{ required: true, message: '请输入发票抬头' }],
-          required: true
-        },
-        {
-          label: '纳税人识别号',
-          placeholder: '请输入纳税人识别号',
-          formItemProp: 'num',
-          rules: [{ message: '请输入纳税人识别号' }]
-        },
-        {
-          label: '注册地址',
-          placeholder: '请输入注册地址',
-          formItemProp: 'adress',
-          rules: [{ required: true, message: '请输入地址' }],
-          required: true
-        },
-        {
-          label: '注册电话',
-          placeholder: '请输入注册电话',
-          formItemProp: 'tel',
-          rules: [
-            { required: true, message: '请输入联系电话' },
-            { validator: asyncValidator, message: '电话格式不正确' }
-          ],
-          required: true
-        },
-        {
-          label: '开户行',
-          placeholder: '请输入开户行',
-          formItemProp: 'bank'
-        },
-        {
-          label: '银行账户',
-          placeholder: '请输入银行账户',
-          formItemProp: 'account'
+          label: '个人或事业单位'
         }
-      ]);
+      ],
+      formItemProp: 'type',
+      required: true
+    },
+    {
+      label: '发票抬头',
+      placeholder: '请输入发票抬头',
+      formItemProp: 'name',
+      rules: [{ required: true, message: '请输入发票抬头' }],
+      required: true
+    },
+    {
+      label: '纳税人识别号',
+      placeholder: '请输入纳税人识别号',
+      formItemProp: 'num',
+      rules: [{ message: '请输入纳税人识别号' }]
+    },
+    {
+      label: '注册地址',
+      placeholder: '请输入注册地址',
+      formItemProp: 'adress',
+      rules: [{ required: true, message: '请输入地址' }],
+      required: true
+    },
+    {
+      label: '注册电话',
+      placeholder: '请输入注册电话',
+      formItemProp: 'tel',
+      rules: [
+        { required: true, message: '请输入联系电话' },
+        { validator: asyncValidator, message: '电话格式不正确' }
+      ],
+      required: true
+    },
+    {
+      label: '开户行',
+      placeholder: '请输入开户行',
+      formItemProp: 'bank'
+    },
+    {
+      label: '银行账户',
+      placeholder: '请输入银行账户',
+      formItemProp: 'account'
+    }
+  ]);
 
-      const formValue = reactive({
-        type: '企业',
-        name: '',
-        num: '',
-        adress: '',
-        tel: '',
-        address: '',
-        bank: '',
-        account: ''
-      });
+  const formValue = reactive({
+    type: '企业',
+    name: '',
+    num: '',
+    adress: '',
+    tel: '',
+    address: '',
+    bank: '',
+    account: ''
+  });
 
-      const submit = (valid: boolean, errors: []) => {
-        if (valid) {
-          console.log('success', formValue);
-        } else {
-          console.log('error submit!!', errors);
-        }
-      };
-
-      return {
-        data,
-        formValue,
-        submit,
-        asyncValidator
-      };
+  const submit = (valid: boolean, errors: []) => {
+    if (valid) {
+      console.log('success', formValue);
+    } else {
+      console.log('error submit!!', errors);
     }
   };
 </script>
@@ -155,9 +140,10 @@ The optional attributes are as follows:
 
 ### Events
 
-| Event     | Description                                | Arguments |
-| --------- | ------------------------------------------ | --------- |
-| on-submit | Method of submitting form for verification | Promise   |
+| Event          | Description                                | Arguments |
+| -------------- | ------------------------------------------ | --------- |
+| submit`v4.1.5` | Method of submitting form for verification | Promise   |
+| on-submit      | Method of submitting form for verification | Promise   |
 
 ## Theming
 

--- a/src/packages/__VUE/invoice/doc.md
+++ b/src/packages/__VUE/invoice/doc.md
@@ -20,107 +20,93 @@ app.use(Invoice);
 
 ```html
 <template>
-  <nut-invoice :data="data" :formValue="formValue" @onSubmit="submit"> </nut-invoice>
+  <nut-invoice :data="data" :form-value="formValue" @submit="submit"></nut-invoice>
 </template>
-<script lang="ts">
+<script setup>
   import { ref, reactive } from 'vue';
-  import { showToast } from '@nutui/nutui';
-  import '@nutui/nutui/dist/packages/toast/style';
-  export default {
-    setup() {
-      // Promise 异步校验
-      const asyncValidator = (val: string) => {
-        return new Promise((resolve) => {
-          showToast.loading('模拟异步验证中...');
-          setTimeout(() => {
-            showToast.hide();
-            resolve(/^400(-?)[0-9]{7}$|^1\d{10}$|^0[0-9]{2,3}-[0-9]{7,8}$/.test(val));
-          }, 1000);
-        });
-      };
+  // Promise 异步校验
+  const asyncValidator = (val: string) => {
+    return new Promise((resolve) => {
+      console.log('模拟异步验证中...');
+      setTimeout(() => {
+        resolve(/^400(-?)[0-9]{7}$|^1\d{10}$|^0[0-9]{2,3}-[0-9]{7,8}$/.test(val));
+      }, 1000);
+    });
+  };
 
-      let data: any = ref([
+  const data: any = ref([
+    {
+      type: 'radio',
+      label: '发票类型',
+      radioLabel: [
         {
-          type: 'radio',
-          label: '发票类型',
-          radioLabel: [
-            {
-              label: '企业'
-            },
-            {
-              label: '个人或事业单位'
-            }
-          ],
-          formItemProp: 'type',
-          required: true
+          label: '企业'
         },
         {
-          label: '发票抬头',
-          placeholder: '请输入发票抬头',
-          formItemProp: 'name',
-          rules: [{ required: true, message: '请输入发票抬头' }],
-          required: true
-        },
-        {
-          label: '纳税人识别号',
-          placeholder: '请输入纳税人识别号',
-          formItemProp: 'num',
-          rules: [{ message: '请输入纳税人识别号' }]
-        },
-        {
-          label: '注册地址',
-          placeholder: '请输入注册地址',
-          formItemProp: 'adress',
-          rules: [{ required: true, message: '请输入地址' }],
-          required: true
-        },
-        {
-          label: '注册电话',
-          placeholder: '请输入注册电话',
-          formItemProp: 'tel',
-          rules: [
-            { required: true, message: '请输入联系电话' },
-            { validator: asyncValidator, message: '电话格式不正确' }
-          ],
-          required: true
-        },
-        {
-          label: '开户行',
-          placeholder: '请输入开户行',
-          formItemProp: 'bank'
-        },
-        {
-          label: '银行账户',
-          placeholder: '请输入银行账户',
-          formItemProp: 'account'
+          label: '个人或事业单位'
         }
-      ]);
+      ],
+      formItemProp: 'type',
+      required: true
+    },
+    {
+      label: '发票抬头',
+      placeholder: '请输入发票抬头',
+      formItemProp: 'name',
+      rules: [{ required: true, message: '请输入发票抬头' }],
+      required: true
+    },
+    {
+      label: '纳税人识别号',
+      placeholder: '请输入纳税人识别号',
+      formItemProp: 'num',
+      rules: [{ message: '请输入纳税人识别号' }]
+    },
+    {
+      label: '注册地址',
+      placeholder: '请输入注册地址',
+      formItemProp: 'adress',
+      rules: [{ required: true, message: '请输入地址' }],
+      required: true
+    },
+    {
+      label: '注册电话',
+      placeholder: '请输入注册电话',
+      formItemProp: 'tel',
+      rules: [
+        { required: true, message: '请输入联系电话' },
+        { validator: asyncValidator, message: '电话格式不正确' }
+      ],
+      required: true
+    },
+    {
+      label: '开户行',
+      placeholder: '请输入开户行',
+      formItemProp: 'bank'
+    },
+    {
+      label: '银行账户',
+      placeholder: '请输入银行账户',
+      formItemProp: 'account'
+    }
+  ]);
 
-      const formValue = reactive({
-        type: '企业',
-        name: '',
-        num: '',
-        adress: '',
-        tel: '',
-        address: '',
-        bank: '',
-        account: ''
-      });
+  const formValue = reactive({
+    type: '企业',
+    name: '',
+    num: '',
+    adress: '',
+    tel: '',
+    address: '',
+    bank: '',
+    account: ''
+  });
 
-      const submit = (valid: boolean, errors: []) => {
-        if (valid) {
-          console.log('success', formValue);
-        } else {
-          console.log('error submit!!', errors);
-        }
-      };
-
-      return {
-        data,
-        formValue,
-        submit,
-        asyncValidator
-      };
+  const submit = (valid: boolean, errors: []) => {
+    if (valid) {
+      console.log('success', formValue);
+    } else {
+      console.log('error submit!!', errors);
     }
   };
 </script>
@@ -154,9 +140,10 @@ app.use(Invoice);
 
 ### Events
 
-| 事件名    | 说明           | 参数 | 返回值  |
-| --------- | -------------- | ---- | ------- |
-| on-submit | 提交表单的方法 | -    | Promise |
+| 事件名         | 说明           | 参数 | 返回值  |
+| -------------- | -------------- | ---- | ------- |
+| submit`v4.1.5` | 提交表单的方法 | -    | Promise |
+| on-submit      | 提交表单的方法 | -    | Promise |
 
 ## 主题定制
 

--- a/src/packages/__VUE/invoice/doc.taro.md
+++ b/src/packages/__VUE/invoice/doc.taro.md
@@ -20,105 +20,93 @@ app.use(Invoice);
 
 ```html
 <template>
-  <nut-invoice :data="data" :formValue="formValue" @onSubmit="submit"> </nut-invoice>
+  <nut-invoice :data="data" :form-value="formValue" @submit="submit"></nut-invoice>
 </template>
-<script lang="ts">
+<script setup>
   import { ref, reactive } from 'vue';
-  export default {
-    setup() {
-      // Promise 异步校验
-      const asyncValidator = (val: string) => {
-        return new Promise((resolve) => {
-          console.log('模拟异步验证中...');
-          setTimeout(() => {
-            console.log('验证完成');
-            resolve(/^400(-?)[0-9]{7}$|^1\d{10}$|^0[0-9]{2,3}-[0-9]{7,8}$/.test(val));
-          }, 1000);
-        });
-      };
+  // Promise 异步校验
+  const asyncValidator = (val: string) => {
+    return new Promise((resolve) => {
+      console.log('模拟异步验证中...');
+      setTimeout(() => {
+        resolve(/^400(-?)[0-9]{7}$|^1\d{10}$|^0[0-9]{2,3}-[0-9]{7,8}$/.test(val));
+      }, 1000);
+    });
+  };
 
-      let data: any = ref([
+  const data: any = ref([
+    {
+      type: 'radio',
+      label: '发票类型',
+      radioLabel: [
         {
-          type: 'radio',
-          label: '发票类型',
-          radioLabel: [
-            {
-              label: '企业'
-            },
-            {
-              label: '个人或事业单位'
-            }
-          ],
-          formItemProp: 'type',
-          required: true
+          label: '企业'
         },
         {
-          label: '发票抬头',
-          placeholder: '请输入发票抬头',
-          formItemProp: 'name',
-          rules: [{ required: true, message: '请输入发票抬头' }],
-          required: true
-        },
-        {
-          label: '纳税人识别号',
-          placeholder: '请输入纳税人识别号',
-          formItemProp: 'num',
-          rules: [{ message: '请输入纳税人识别号' }]
-        },
-        {
-          label: '注册地址',
-          placeholder: '请输入注册地址',
-          formItemProp: 'adress',
-          rules: [{ required: true, message: '请输入地址' }],
-          required: true
-        },
-        {
-          label: '注册电话',
-          placeholder: '请输入注册电话',
-          formItemProp: 'tel',
-          rules: [
-            { required: true, message: '请输入联系电话' },
-            { validator: asyncValidator, message: '电话格式不正确' }
-          ],
-          required: true
-        },
-        {
-          label: '开户行',
-          placeholder: '请输入开户行',
-          formItemProp: 'bank'
-        },
-        {
-          label: '银行账户',
-          placeholder: '请输入银行账户',
-          formItemProp: 'account'
+          label: '个人或事业单位'
         }
-      ]);
+      ],
+      formItemProp: 'type',
+      required: true
+    },
+    {
+      label: '发票抬头',
+      placeholder: '请输入发票抬头',
+      formItemProp: 'name',
+      rules: [{ required: true, message: '请输入发票抬头' }],
+      required: true
+    },
+    {
+      label: '纳税人识别号',
+      placeholder: '请输入纳税人识别号',
+      formItemProp: 'num',
+      rules: [{ message: '请输入纳税人识别号' }]
+    },
+    {
+      label: '注册地址',
+      placeholder: '请输入注册地址',
+      formItemProp: 'adress',
+      rules: [{ required: true, message: '请输入地址' }],
+      required: true
+    },
+    {
+      label: '注册电话',
+      placeholder: '请输入注册电话',
+      formItemProp: 'tel',
+      rules: [
+        { required: true, message: '请输入联系电话' },
+        { validator: asyncValidator, message: '电话格式不正确' }
+      ],
+      required: true
+    },
+    {
+      label: '开户行',
+      placeholder: '请输入开户行',
+      formItemProp: 'bank'
+    },
+    {
+      label: '银行账户',
+      placeholder: '请输入银行账户',
+      formItemProp: 'account'
+    }
+  ]);
 
-      const formValue = reactive({
-        type: '企业',
-        name: '',
-        num: '',
-        adress: '',
-        tel: '',
-        address: '',
-        bank: '',
-        account: ''
-      });
+  const formValue = reactive({
+    type: '企业',
+    name: '',
+    num: '',
+    adress: '',
+    tel: '',
+    address: '',
+    bank: '',
+    account: ''
+  });
 
-      const submit = (valid: boolean, errors: []) => {
-        if (valid) {
-          console.log('success', formValue);
-        } else {
-          console.log('error submit!!', errors);
-        }
-      };
-
-      return {
-        data,
-        formValue,
-        submit,
-        asyncValidator
-      };
+  const submit = (valid: boolean, errors: []) => {
+    if (valid) {
+      console.log('success', formValue);
+    } else {
+      console.log('error submit!!', errors);
     }
   };
 </script>
@@ -152,9 +140,10 @@ app.use(Invoice);
 
 ### Events
 
-| 事件名    | 说明           | 参数 | 返回值  |
-| --------- | -------------- | ---- | ------- |
-| on-submit | 提交表单的方法 | -    | Promise |
+| 事件名         | 说明           | 参数 | 返回值  |
+| -------------- | -------------- | ---- | ------- |
+| submit`v4.1.5` | 提交表单的方法 | -    | Promise |
+| on-submit      | 提交表单的方法 | -    | Promise |
 
 ## 主题定制
 

--- a/src/packages/__VUE/invoice/index.taro.vue
+++ b/src/packages/__VUE/invoice/index.taro.vue
@@ -67,7 +67,12 @@ export default create({
       default: true
     }
   },
-  emits: ['onSubmit', 'scrollBottom'],
+  emits: [
+    'submit',
+    'scrollBottom',
+    // will be deprecated
+    'onSubmit'
+  ],
 
   setup(props, { emit }) {
     const formRef = ref();
@@ -95,6 +100,7 @@ export default create({
 
     const submitFun = () => {
       formRef.value.validate().then(({ valid, errors }: any) => {
+        emit('submit', valid, errors);
         emit('onSubmit', valid, errors);
       });
     };

--- a/src/packages/__VUE/invoice/index.vue
+++ b/src/packages/__VUE/invoice/index.vue
@@ -67,7 +67,12 @@ export default create({
       default: true
     }
   },
-  emits: ['onSubmit', 'scrollBottom'],
+  emits: [
+    'submit',
+    'scrollBottom',
+    // will be deprecated
+    'onSubmit'
+  ],
 
   setup(props, { emit }) {
     const formRef = ref();
@@ -95,6 +100,7 @@ export default create({
 
     const submitFun = () => {
       formRef.value.validate().then(({ valid, errors }: any) => {
+        emit('submit', valid, errors);
         emit('onSubmit', valid, errors);
       });
     };

--- a/src/packages/__VUE/navbar/__test__/navbar.spec.ts
+++ b/src/packages/__VUE/navbar/__test__/navbar.spec.ts
@@ -48,13 +48,13 @@ test('Navbar: emit click-left & click-right', () => {
   });
 
   wrapper.find('.nut-navbar__left').trigger('click');
-  expect(wrapper.emitted('onClickBack')).toBeTruthy();
+  expect(wrapper.emitted('clickBack')).toBeTruthy();
   wrapper.find('.nut-navbar__right').trigger('click');
-  expect(wrapper.emitted('onClickRight')).toBeTruthy();
+  expect(wrapper.emitted('clickRight')).toBeTruthy();
   wrapper.find('.nut-navbar__title .title').trigger('click');
-  expect(wrapper.emitted('onClickTitle')).toBeTruthy();
+  expect(wrapper.emitted('clickTitle')).toBeTruthy();
   wrapper.find('.nut-navbar__title .icon').trigger('click');
-  expect(wrapper.emitted('onClickIcon')).toBeTruthy();
+  expect(wrapper.emitted('clickIcon')).toBeTruthy();
 });
 
 test('Navbar: should change z-index when using z-index prop', async () => {

--- a/src/packages/__VUE/navbar/demo.vue
+++ b/src/packages/__VUE/navbar/demo.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="demo full">
     <h2>{{ translate('title1') }}</h2>
-    <nut-navbar :title="translate('navTitle1')" @on-click-back="back" @on-click-title="title">
+    <nut-navbar :title="translate('navTitle1')" @click-back="back" @click-title="title">
       <template #left>
         <div>{{ translate('back') }}</div>
       </template>
@@ -13,9 +13,9 @@
     <nut-navbar
       :title="translate('navTitle2')"
       :desc="translate('desc1')"
-      @on-click-back="back"
-      @on-click-title="title"
-      @on-click-right="rightClick"
+      @click-back="back"
+      @click-title="title"
+      @click-right="rightClick"
     ></nut-navbar>
 
     <nut-navbar
@@ -23,10 +23,10 @@
       :title="translate('navTitle3')"
       :title-icon="true"
       :desc="translate('desc2')"
-      @on-click-back="back"
-      @on-click-title="title"
-      @on-click-icon="icon"
-      @on-click-right="rightClick"
+      @click-back="back"
+      @click-title="title"
+      @click-icon="icon"
+      @click-right="rightClick"
     >
       <template #title-icon>
         <Cart2 width="16px"></Cart2>
@@ -37,7 +37,7 @@
     </nut-navbar>
 
     <h2>{{ translate('title2') }}</h2>
-    <nut-navbar :desc="translate('desc2')" @on-click-back="back" @on-click-title="title" @on-click-right="rightClick">
+    <nut-navbar :desc="translate('desc2')" @click-back="back" @click-title="title" @click-right="rightClick">
       <template #content>
         <nut-tabs v-model="tab1value" @click="changeTab">
           <nut-tab-pane :title="translate('tab1')"> </nut-tab-pane>
@@ -51,7 +51,7 @@
     </nut-navbar>
 
     <h2>{{ translate('title3') }}</h2>
-    <nut-navbar @on-click-back="back">
+    <nut-navbar @click-back="back">
       <template #content>
         <nut-tabs v-model="tab2value" @click="changeTabList">
           <nut-tab-pane :title="translate('tab1')"> </nut-tab-pane>

--- a/src/packages/__VUE/navbar/doc.en-US.md
+++ b/src/packages/__VUE/navbar/doc.en-US.md
@@ -20,7 +20,7 @@ app.use(Navbar);
 
 ```vue
 <template>
-  <nut-navbar @on-click-back="back" @on-click-title="title" title="Order details">
+  <nut-navbar @click-back="back" @click-title="title" title="Order details">
     <template #left>
       <div>Back</div>
     </template>
@@ -30,19 +30,19 @@ app.use(Navbar);
   </nut-navbar>
 
   <nut-navbar
-    @on-click-back="back"
-    @on-click-title="title"
-    @on-click-right="rightClick"
+    @click-back="back"
+    @click-title="title"
+    @click-right="rightClick"
     title="Browsing history"
     desc="Clear"
   ></nut-navbar>
 
   <nut-navbar
     :left-show="false"
-    @on-click-back="back"
-    @on-click-title="title"
-    @on-click-icon="icon"
-    @on-click-right="rightClick"
+    @click-back="back"
+    @click-title="title"
+    @click-icon="icon"
+    @click-right="rightClick"
     title="Cart"
     :titleIcon="true"
     desc="Edit"
@@ -81,7 +81,7 @@ const icon = () => {
 
 ```vue
 <template>
-  <nut-navbar @on-click-back="back" @on-click-title="title" @on-click-right="rightClick" desc="Edit">
+  <nut-navbar @click-back="back" @click-title="title" @click-right="rightClick" desc="Edit">
     <template #content>
       <nut-tabs v-model="tab1value" @click="changeTab">
         <nut-tab-pane title="Title1"> </nut-tab-pane>
@@ -122,7 +122,7 @@ const changeTab = (tab) => {
 
 ```vue
 <template>
-  <nut-navbar @on-click-back="back">
+  <nut-navbar @click-back="back">
     <template #content>
       <nut-tabs v-model="tab2value" @click="changeTabList">
         <nut-tab-pane title="Title1"> </nut-tab-pane>
@@ -171,12 +171,16 @@ const changeTabList = (tab) => {
 
 ### Events
 
-| Event          | Description                     | Arguments   |
-| -------------- | ------------------------------- | ----------- |
-| on-click-title | Click page title event          | event:Event |
-| on-click-icon  | Click the page title icon event | event:Event |
-| on-click-right | Click right button event        | event:Event |
-| on-click-back  | Click left Icon event           | event:Event |
+| Event              | Description                     | Arguments   |
+| ------------------ | ------------------------------- | ----------- |
+| click-title`4.1.5` | Click page title event          | event:Event |
+| click-icon`4.1.5`  | Click the page title icon event | event:Event |
+| click-right`4.1.5` | Click right button event        | event:Event |
+| click-back`4.1.5`  | Click left Icon event           | event:Event |
+| on-click-title     | Click page title event          | event:Event |
+| on-click-icon      | Click the page title icon event | event:Event |
+| on-click-right     | Click right button event        | event:Event |
+| on-click-back      | Click left Icon event           | event:Event |
 
 ### Slots
 

--- a/src/packages/__VUE/navbar/doc.md
+++ b/src/packages/__VUE/navbar/doc.md
@@ -20,7 +20,7 @@ app.use(Navbar);
 
 ```vue
 <template>
-  <nut-navbar @on-click-back="back" @on-click-title="title" title="订单详情">
+  <nut-navbar @click-back="back" @click-title="title" title="订单详情">
     <template #left>
       <div>返回</div>
     </template>
@@ -30,19 +30,19 @@ app.use(Navbar);
   </nut-navbar>
 
   <nut-navbar
-    @on-click-back="back"
-    @on-click-title="title"
-    @on-click-right="rightClick"
+    @click-back="back"
+    @click-title="title"
+    @click-right="rightClick"
     title="浏览记录"
     desc="清空"
   ></nut-navbar>
 
   <nut-navbar
     :left-show="false"
-    @on-click-back="back"
-    @on-click-title="title"
-    @on-click-icon="icon"
-    @on-click-right="rightClick"
+    @click-back="back"
+    @click-title="title"
+    @click-icon="icon"
+    @click-right="rightClick"
     title="购物车"
     :titleIcon="true"
     desc="编辑"
@@ -81,7 +81,7 @@ const icon = () => {
 
 ```vue
 <template>
-  <nut-navbar @on-click-back="back" @on-click-title="title" @on-click-right="rightClick" desc="编辑">
+  <nut-navbar @click-back="back" @click-title="title" @click-right="rightClick" desc="编辑">
     <template #content>
       <nut-tabs v-model="tab1value" @click="changeTab">
         <nut-tab-pane title="标题1"> </nut-tab-pane>
@@ -122,7 +122,7 @@ const changeTab = (tab) => {
 
 ```vue
 <template>
-  <nut-navbar @on-click-back="back">
+  <nut-navbar @click-back="back">
     <template #content>
       <nut-tabs v-model="tab2value" @click="changeTabList">
         <nut-tab-pane title="标题1"> </nut-tab-pane>
@@ -171,12 +171,16 @@ const changeTabList = (tab) => {
 
 ### Events
 
-| 事件名         | 说明                     | 回调参数    |
-| -------------- | ------------------------ | ----------- |
-| on-click-title | 点击页面标题事件         | event:Event |
-| on-click-icon  | 点击页面标题 `icon` 事件 | event:Event |
-| on-click-right | 点击右侧按钮事件         | event:Event |
-| on-click-back  | 点击左侧图标事件         | event:Event |
+| 事件名             | 说明                     | 回调参数    |
+| ------------------ | ------------------------ | ----------- |
+| click-title`4.1.5` | 点击页面标题事件         | event:Event |
+| click-icon`4.1.5`  | 点击页面标题 `icon` 事件 | event:Event |
+| click-right`4.1.5` | 点击右侧按钮事件         | event:Event |
+| click-back`4.1.5`  | 点击左侧图标事件         | event:Event |
+| on-click-title     | 点击页面标题事件         | event:Event |
+| on-click-icon      | 点击页面标题 `icon` 事件 | event:Event |
+| on-click-right     | 点击右侧按钮事件         | event:Event |
+| on-click-back      | 点击左侧图标事件         | event:Event |
 
 ### Slots
 

--- a/src/packages/__VUE/navbar/doc.taro.md
+++ b/src/packages/__VUE/navbar/doc.taro.md
@@ -20,7 +20,7 @@ app.use(Navbar);
 
 ```vue
 <template>
-  <nut-navbar @on-click-back="back" @on-click-title="title" title="订单详情">
+  <nut-navbar @click-back="back" @click-title="title" title="订单详情">
     <template #left>
       <div>返回</div>
     </template>
@@ -30,19 +30,19 @@ app.use(Navbar);
   </nut-navbar>
 
   <nut-navbar
-    @on-click-back="back"
-    @on-click-title="title"
-    @on-click-right="rightClick"
+    @click-back="back"
+    @click-title="title"
+    @click-right="rightClick"
     title="浏览记录"
     desc="清空"
   ></nut-navbar>
 
   <nut-navbar
     :left-show="false"
-    @on-click-back="back"
-    @on-click-title="title"
-    @on-click-icon="icon"
-    @on-click-right="rightClick"
+    @click-back="back"
+    @click-title="title"
+    @click-icon="icon"
+    @click-right="rightClick"
     title="购物车"
     :titleIcon="true"
     desc="编辑"
@@ -81,7 +81,7 @@ const icon = () => {
 
 ```vue
 <template>
-  <nut-navbar @on-click-back="back" @on-click-title="title" @on-click-right="rightClick" desc="编辑">
+  <nut-navbar @click-back="back" @click-title="title" @click-right="rightClick" desc="编辑">
     <template #content>
       <nut-tabs v-model="tab1value" @click="changeTab">
         <nut-tab-pane title="标题1"> </nut-tab-pane>
@@ -122,7 +122,7 @@ const changeTab = (tab) => {
 
 ```vue
 <template>
-  <nut-navbar @on-click-back="back">
+  <nut-navbar @click-back="back">
     <template #content>
       <nut-tabs v-model="tab2value" @click="changeTabList">
         <nut-tab-pane title="标题1"> </nut-tab-pane>
@@ -171,12 +171,16 @@ const changeTabList = (tab) => {
 
 ### Events
 
-| 事件名         | 说明                     | 回调参数    |
-| -------------- | ------------------------ | ----------- |
-| on-click-title | 点击页面标题事件         | event:Event |
-| on-click-icon  | 点击页面标题 `icon` 事件 | event:Event |
-| on-click-right | 点击右侧按钮事件         | event:Event |
-| on-click-back  | 点击左侧图标事件         | event:Event |
+| 事件名             | 说明                     | 回调参数    |
+| ------------------ | ------------------------ | ----------- |
+| click-title`4.1.5` | 点击页面标题事件         | event:Event |
+| click-icon`4.1.5`  | 点击页面标题 `icon` 事件 | event:Event |
+| click-right`4.1.5` | 点击右侧按钮事件         | event:Event |
+| click-back`4.1.5`  | 点击左侧图标事件         | event:Event |
+| on-click-title     | 点击页面标题事件         | event:Event |
+| on-click-icon      | 点击页面标题 `icon` 事件 | event:Event |
+| on-click-right     | 点击右侧按钮事件         | event:Event |
+| on-click-back      | 点击左侧图标事件         | event:Event |
 
 ### Slots
 

--- a/src/packages/__VUE/navbar/index.taro.vue
+++ b/src/packages/__VUE/navbar/index.taro.vue
@@ -59,7 +59,17 @@ export default create({
       default: 10
     }
   },
-  emits: ['onClickBack', 'onClickTitle', 'onClickIcon', 'onClickRight'],
+  emits: [
+    'clickBack',
+    'clickTitle',
+    'clickIcon',
+    'clickRight',
+    // will be deprecated
+    'onClickBack',
+    'onClickTitle',
+    'onClickIcon',
+    'onClickRight'
+  ],
   setup(props, { emit }) {
     const { border, fixed, safeAreaInsetTop, placeholder } = toRefs(props);
     const refRandomId = Math.random().toString(36).slice(-8);
@@ -102,18 +112,22 @@ export default create({
     });
 
     const handleLeft = () => {
+      emit('clickBack');
       emit('onClickBack');
     };
 
     const handleCenter = () => {
+      emit('clickTitle');
       emit('onClickTitle');
     };
 
     const handleCenterIcon = () => {
+      emit('clickIcon');
       emit('onClickIcon');
     };
 
     const handleRight = () => {
+      emit('clickRight');
       emit('onClickRight');
     };
 

--- a/src/packages/__VUE/navbar/index.vue
+++ b/src/packages/__VUE/navbar/index.vue
@@ -58,7 +58,17 @@ export default create({
       default: 10
     }
   },
-  emits: ['onClickBack', 'onClickTitle', 'onClickIcon', 'onClickRight'],
+  emits: [
+    'clickBack',
+    'clickTitle',
+    'clickIcon',
+    'clickRight',
+    // will be deprecated
+    'onClickBack',
+    'onClickTitle',
+    'onClickIcon',
+    'onClickRight'
+  ],
   setup(props, { emit }) {
     const { border, fixed, safeAreaInsetTop, placeholder } = toRefs(props);
     const navHeight = ref('auto');
@@ -98,18 +108,22 @@ export default create({
     });
 
     const handleLeft = () => {
+      emit('clickBack');
       emit('onClickBack');
     };
 
     const handleCenter = () => {
+      emit('clickTitle');
       emit('onClickTitle');
     };
 
     const handleCenterIcon = () => {
+      emit('clickIcon');
       emit('onClickIcon');
     };
 
     const handleRight = () => {
+      emit('clickRight');
       emit('onClickRight');
     };
 


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/jdf2e/nutui/issues/1671
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

存在的问题：部分组件的事件名称中存在 `on` 前缀，并不符合 Vue 组件的命名风格。
调整：
- 新增不带 on 前缀名称的事件
- 保留原事件以兼容版本升级，将会在下个大版本移除
涉及范围：
- countdown: end、restart、paused
- invoice: submit
- navbr: click

**这个 PR 是什么类型?** (至少选择一个)

- [x] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [x] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [x] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

**这个 PR 涉及以下平台:**

- [x] NutUI 4.0 H5
- [x] NutUI 4.0 小程序
- [ ] NutUI 3.0 H5
- [ ] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [x] 自测 Vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/nutui4-vue/vite-ts)
- [x] 自测 Taro 脚手架使用小程序 & Taro-H5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/nutui4-vue/taro)
