### PR TITLE
fix(calendar): 修正 demo 默认文案显示条件

### DIFF
--- a/src/packages/__VUE/calendar/demo.vue
+++ b/src/packages/__VUE/calendar/demo.vue
@@ -24,7 +24,7 @@
       <nut-cell
         :show-icon="true"
         :title="translate('range')"
-        :desc="date1 ? `${date1[0]}${translate('conjunction')}${date1[1]}` : translate('please')"
+        :desc="date1.length ? `${date1[0]}${translate('conjunction')}${date1[1]}` : translate('please')"
         @click="openSwitch('isVisible1')"
       >
       </nut-cell>
@@ -105,7 +105,7 @@
       <nut-cell
         :show-icon="true"
         :title="translate('range')"
-        :desc="date4 ? `${date4[0]}${translate('conjunction')}${date4[1]}` : translate('please')"
+        :desc="date4.length ? `${date4[0]}${translate('conjunction')}${date4[1]}` : translate('please')"
         @click="openSwitch('isVisible4')"
       >
       </nut-cell>


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)
1 存在的问题：
demo 示例中，如果日期区间的数据为空数组，文案会显示'undefined至undefined'，略不美观.
2 调整:
三元表达式的条件改为 data.length ，数组为空时展示默认文案
**这个 PR 是什么类型?** (至少选择一个)

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [x] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

**这个 PR 涉及以下平台:**

- [x] NutUI 4.0 H5
- [x] NutUI 4.0 小程序
- [ ] NutUI 3.0 H5
- [ ] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [x] 自测 Vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/nutui4-vue/vite-ts)
- [ ] 自测 Taro 脚手架使用小程序 & Taro-H5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/nutui4-vue/taro)
