### PR TITLE
fix(configprovider): slot is not reactive

### DIFF
--- a/src/packages/__VUE/configprovider/common.ts
+++ b/src/packages/__VUE/configprovider/common.ts
@@ -63,7 +63,6 @@ export const component = (tag: string) => {
       };
 
       const themeStyle = computed(() => mapThemeVarsToCSSVars(props.themeVars));
-      const defaultSlots = slots.default?.();
 
       return () => {
         return h(
@@ -72,7 +71,7 @@ export const component = (tag: string) => {
             class: `nut-theme-${props.theme}`,
             style: themeStyle.value
           },
-          defaultSlots
+          slots.default?.()
         );
       };
     }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/jdf2e/nutui/issues/1671
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

slots 中的属性并不是响应式的，在原有逻辑下，config-provider 的直接子组件（默认插槽）的响应性将会丢失

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

**这个 PR 涉及以下平台:**

- [x] NutUI 4.0 H5
- [x] NutUI 4.0 小程序
- [ ] NutUI 3.0 H5
- [ ] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [x] 自测 Vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/nutui4-vue/vite-ts)
- [x] 自测 Taro 脚手架使用小程序 & Taro-H5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/nutui4-vue/taro)
