### PR TITLE
feat(searchbar): 增加safe-area-inset-bottom属性(#2265)

### DIFF
--- a/src/packages/__VUE/searchbar/doc.en-US.md
+++ b/src/packages/__VUE/searchbar/doc.en-US.md
@@ -220,15 +220,17 @@ background | external background of the input box | string | `#fff` | | input-ba
 string | `#f7f7f7` | | autofocus | Whether to automatically focus | boolean | `false` | | focus-style | search box style
 when focused | Object | `-` | | disabled | Whether to disable the input box | boolean | `false` | | readonly| input
 field is read only | boolean | `false` | | input-align| alignment, optional `left` `center` `right` | string | `left` |
-### Events | Event Name | Description | Callback Parameters | |--------|----------------|--------------| | change |
-fires when something is entered | `val, event` | | focus | fires on focus | `val, event` | | blur | Triggered when out
-of focus | `val, event` | | clear | Triggered when click clear | `val` | | search | fires when the ENTER key is pressed
-| `val, event` | | click-input| Fired when the input field is clicked | `event` | | click-left-icon| Fires when the left
-icon is clicked | `val, event` | | click-right-icon| Fires when the right icon is clicked | `val, event` | ### Slots |
-Name | Description | |---------------|----------------------| |leftIn | left icon in the input box| |leftout | left Icon
-outside the input box| |rightin | right icon in the input box| |rightout | right icon outside the input box| ## Theming
-### CSS Variables The component provides the following CSS variables, which can be used to customize styles. Please
-refer to [ConfigProvider component](#/en-US/component/configprovider). | Name | Default Value | |
+| safe-area-inset-bottom | Whether to enable the security zone at the bottom of the full screen of iphone series |
+boolean | `false` | ### Events | Event Name | Description | Callback Parameters |
+|--------|----------------|--------------| | change | fires when something is entered | `val, event` | | focus | fires
+on focus | `val, event` | | blur | Triggered when out of focus | `val, event` | | clear | Triggered when click clear |
+`val` | | search | fires when the ENTER key is pressed | `val, event` | | click-input| Fired when the input field is
+clicked | `event` | | click-left-icon| Fires when the left icon is clicked | `val, event` | | click-right-icon| Fires
+when the right icon is clicked | `val, event` | ### Slots | Name | Description |
+|---------------|----------------------| |leftIn | left icon in the input box| |leftout | left Icon outside the input
+box| |rightin | right icon in the input box| |rightout | right icon outside the input box| ## Theming ### CSS Variables
+The component provides the following CSS variables, which can be used to customize styles. Please refer to
+[ConfigProvider component](#/en-US/component/configprovider). | Name | Default Value | |
 --------------------------------------- | -------------------------- | | --nut-searchbar-background| _var(--nut-white)_
 | | --nut-searchbar-right-out-color| _var(--nut-black)_ | | --nut-searchbar-padding| _9px 16px_ | |
 --nut-searchbar-width| _100%_ | | --nut-searchbar-input-background| _#f7f7f7_ | | --nut-searchbar-input-padding| _0 0 0

--- a/src/packages/__VUE/searchbar/doc.md
+++ b/src/packages/__VUE/searchbar/doc.md
@@ -250,23 +250,24 @@ app.use(Searchbar);
 
 ### Props
 
-| 参数             | 说明                                                | 类型             | 默认值        |
-| ---------------- | --------------------------------------------------- | ---------------- | ------------- |
-| v-model          | 当前输入的值                                        | number \| string | `''`          |
-| label            | 搜索框左侧文本                                      | string           | `''`          |
-| shape            | 搜索框形状，可选值为 `square` `round`               | string           | `round`       |
-| max-length       | 最大输入长度                                        | number \| string | `9999`        |
-| input-type       | 输入框类型                                          | string           | `text`        |
-| placeholder      | 输入框默认暗纹                                      | string           | `请输入`      |
-| clearable        | 是否展示清除按钮                                    | boolean          | `true`        |
-| clear-icon       | 自定义清除按钮图标（默认使用 `@nutui/nutui-icons`） | Object           | `CircleClose` |
-| background       | 输入框外部背景                                      | string           | `#fff`        |
-| input-background | 输入框内部背景                                      | string           | `#f7f7f7`     |
-| autofocus        | 是否自动聚焦                                        | boolean          | `false`       |
-| focus-style      | 聚焦时搜索框样式                                    | Object           | `-`           |
-| disabled         | 是否禁用输入框                                      | boolean          | `false`       |
-| readonly         | 输入框只读                                          | boolean          | `false`       |
-| input-align      | 对齐方式，可选`left` `center` `right`               | string           | `left`        |
+| 参数                   | 说明                                                | 类型             | 默认值        |
+| ---------------------- | --------------------------------------------------- | ---------------- | ------------- |
+| v-model                | 当前输入的值                                        | number \| string | `''`          |
+| label                  | 搜索框左侧文本                                      | string           | `''`          |
+| shape                  | 搜索框形状，可选值为 `square` `round`               | string           | `round`       |
+| max-length             | 最大输入长度                                        | number \| string | `9999`        |
+| input-type             | 输入框类型                                          | string           | `text`        |
+| placeholder            | 输入框默认暗纹                                      | string           | `请输入`      |
+| clearable              | 是否展示清除按钮                                    | boolean          | `true`        |
+| clear-icon             | 自定义清除按钮图标（默认使用 `@nutui/nutui-icons`） | Object           | `CircleClose` |
+| background             | 输入框外部背景                                      | string           | `#fff`        |
+| input-background       | 输入框内部背景                                      | string           | `#f7f7f7`     |
+| autofocus              | 是否自动聚焦                                        | boolean          | `false`       |
+| focus-style            | 聚焦时搜索框样式                                    | Object           | `-`           |
+| disabled               | 是否禁用输入框                                      | boolean          | `false`       |
+| readonly               | 输入框只读                                          | boolean          | `false`       |
+| input-align            | 对齐方式，可选`left` `center` `right`               | string           | `left`        |
+| safe-area-inset-bottom | 是否开启 iphone 系列全面屏底部安全区适配            | boolean          | `false`       |
 
 ### Events
 

--- a/src/packages/__VUE/searchbar/doc.taro.md
+++ b/src/packages/__VUE/searchbar/doc.taro.md
@@ -247,24 +247,25 @@ app.use(Searchbar);
 
 ### Props
 
-| 参数             | 说明                                                                                                                         | 类型             | 默认值        |
-| ---------------- | ---------------------------------------------------------------------------------------------------------------------------- | ---------------- | ------------- |
-| v-model          | 当前输入的值                                                                                                                 | number \| string | `''`          |
-| label            | 搜索框左侧文本                                                                                                               | string           | `''`          |
-| shape            | 搜索框形状，可选值为 `square` `round`                                                                                        | string           | `round`       |
-| max-length       | 最大输入长度                                                                                                                 | number \| string | `9999`        |
-| input-type       | 输入框类型                                                                                                                   | string           | `text`        |
-| placeholder      | 输入框默认暗纹                                                                                                               | string           | `请输入`      |
-| clearable        | 是否展示清除按钮                                                                                                             | boolean          | `true`        |
-| clear-icon       | 自定义清除按钮图标（默认使用 `@nutui/nutui-icons`）                                                                          | Object           | `CircleClose` |
-| background       | 输入框外部背景                                                                                                               | string           | `#fff`        |
-| input-background | 输入框内部背景                                                                                                               | string           | `#f7f7f7`     |
-| confirm-type     | 键盘右下角按钮的文字，仅在`type='text'`时生效，可选值 `send`：发送、`search`：搜索、`next`：下一个、`go`：前往、`done`：完成 | string           | `done`        |
-| autofocus        | 是否自动聚焦                                                                                                                 | boolean          | `false`       |
-| focus-style      | 聚焦时搜索框样式                                                                                                             | Object           | `-`           |
-| disabled         | 是否禁用输入框                                                                                                               | boolean          | `false`       |
-| readonly         | 输入框只读                                                                                                                   | boolean          | `false`       |
-| input-align      | 对齐方式，可选 `left` `center` `right`                                                                                       | string           | `left`        |
+| 参数                   | 说明                                                                                                                         | 类型             | 默认值        |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------- | ---------------- | ------------- |
+| v-model                | 当前输入的值                                                                                                                 | number \| string | `''`          |
+| label                  | 搜索框左侧文本                                                                                                               | string           | `''`          |
+| shape                  | 搜索框形状，可选值为 `square` `round`                                                                                        | string           | `round`       |
+| max-length             | 最大输入长度                                                                                                                 | number \| string | `9999`        |
+| input-type             | 输入框类型                                                                                                                   | string           | `text`        |
+| placeholder            | 输入框默认暗纹                                                                                                               | string           | `请输入`      |
+| clearable              | 是否展示清除按钮                                                                                                             | boolean          | `true`        |
+| clear-icon             | 自定义清除按钮图标（默认使用 `@nutui/nutui-icons`）                                                                          | Object           | `CircleClose` |
+| background             | 输入框外部背景                                                                                                               | string           | `#fff`        |
+| input-background       | 输入框内部背景                                                                                                               | string           | `#f7f7f7`     |
+| confirm-type           | 键盘右下角按钮的文字，仅在`type='text'`时生效，可选值 `send`：发送、`search`：搜索、`next`：下一个、`go`：前往、`done`：完成 | string           | `done`        |
+| autofocus              | 是否自动聚焦                                                                                                                 | boolean          | `false`       |
+| focus-style            | 聚焦时搜索框样式                                                                                                             | Object           | `-`           |
+| disabled               | 是否禁用输入框                                                                                                               | boolean          | `false`       |
+| readonly               | 输入框只读                                                                                                                   | boolean          | `false`       |
+| input-align            | 对齐方式，可选 `left` `center` `right`                                                                                       | string           | `left`        |
+| safe-area-inset-bottom | 是否开启 iphone 系列全面屏底部安全区适配                                                                                     | boolean          | `false`       |
 
 ### Events
 

--- a/src/packages/__VUE/searchbar/index.scss
+++ b/src/packages/__VUE/searchbar/index.scss
@@ -28,6 +28,22 @@
   box-sizing: border-box;
   color: $searchbar-input-bar-color;
 
+  &.safe-area-inset-bottom {
+    position: relative;
+    margin-bottom: constant(safe-area-inset-bottom);
+    margin-bottom: env(safe-area-inset-bottom);
+    &::after {
+      content: '';
+      position: absolute;
+      left: 0;
+      bottom: 0;
+      width: 100%;
+      height: constant(safe-area-inset-bottom);
+      height: env(safe-area-inset-bottom);
+      background: $searchbar-background;
+    }
+  }
+
   &::placeholder {
     color: $searchbar-input-bar-placeholder-color;
   }

--- a/src/packages/__VUE/searchbar/index.taro.vue
+++ b/src/packages/__VUE/searchbar/index.taro.vue
@@ -1,5 +1,5 @@
 <template>
-  <view class="nut-searchbar" :style="searchbarStyle">
+  <view class="nut-searchbar" :class="{ 'safe-area-inset-bottom': safeAreaInsetBottom }" :style="searchbarStyle">
     <view v-if="$slots.leftout" class="nut-searchbar__search-icon nut-searchbar__left-search-icon">
       <slot name="leftout"></slot>
     </view>
@@ -120,6 +120,10 @@ export default create({
     confirmType: {
       type: String as PropType<confirmTextType>,
       default: 'done'
+    },
+    safeAreaInsetBottom: {
+      type: Boolean,
+      default: false
     }
   },
 

--- a/src/packages/__VUE/searchbar/index.vue
+++ b/src/packages/__VUE/searchbar/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <view class="nut-searchbar" :style="searchbarStyle">
+  <view class="nut-searchbar" :class="{ 'safe-area-inset-bottom': safeAreaInsetBottom }" :style="searchbarStyle">
     <span v-if="label" class="nut-searchbar__search-label">{{ label }}</span>
     <view v-if="$slots.leftout" class="nut-searchbar__search-icon nut-searchbar__left-search-icon">
       <slot name="leftout"></slot>
@@ -121,6 +121,10 @@ export default create({
     inputAlign: {
       type: String,
       default: 'left'
+    },
+    safeAreaInsetBottom: {
+      type: Boolean,
+      default: false
     }
   },
 


### PR DESCRIPTION

**这个 PR 做了什么?** (简要描述所做更改)
feat(searchbar): 增加safe-area-inset-bottom属性来保证不会被iphone部分机型遮挡(#2265)

**这个 PR 是什么类型?** (至少选择一个)

- [x] 新特性提交
- [ ] 日常 bug 修复
- [x] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

**这个 PR 涉及以下平台:**

- [x] NutUI 4.0 H5
- [x] NutUI 4.0 小程序
- [ ] NutUI 3.0 H5
- [ ] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [ ] 自测 Vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/nutui4-vue/vite-ts)
- [ ] 自测 Taro 脚手架使用小程序 & Taro-H5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/nutui4-vue/taro)
