### PR TITLE
fix(tabs): 修复组件item设置disabled时，还能滑动到过去的问题(#2486)

### DIFF
--- a/src/packages/__VUE/tabs/__tests__/index.spec.tsx
+++ b/src/packages/__VUE/tabs/__tests__/index.spec.tsx
@@ -166,6 +166,37 @@ test('base Tabpane Props', async () => {
   expect(tab3[0].html()).toContain('Tab 1');
 });
 
+test('base Tabpane disabled swipeable', async () => {
+  const wrapper = mount({
+    components: {
+      'nut-tabs': Tabs,
+      'nut-tab-pane': TabPane
+    },
+    template: `
+    <nut-tabs v-model="state.tab2value" swipeable>
+      <nut-tab-pane title="Tab 1" pane-key="0"> </nut-tab-pane>
+      <nut-tab-pane title="Tab 2" pane-key="1" :disabled="true"> Tab 2 </nut-tab-pane>
+      <nut-tab-pane title="Tab 3" pane-key="2"> Tab 3 </nut-tab-pane>
+    </nut-tabs>
+    `,
+    setup() {
+      const state = reactive({
+        tab2value: '0'
+      });
+      return { state };
+    }
+  });
+  await nextTick();
+  const tab = wrapper.findAll('.nut-tabs__titles-item');
+  expect(tab.length).toBe(3);
+  const tab1 = wrapper.findAll('.nut-tabs__titles-item')[1];
+  expect(tab1.classes()).toContain('disabled');
+  const tab2 = wrapper.findAll('.nut-tabs__titles-item')[0];
+  expect(tab2.classes()).toContain('active');
+  const tab3 = wrapper.findAll('.nut-tabs__titles-item__text');
+  expect(tab3[0].html()).toContain('Tab 1');
+});
+
 test('base click', async () => {
   const wrapper = mount({
     components: {

--- a/src/packages/__VUE/tabs/index.vue
+++ b/src/packages/__VUE/tabs/index.vue
@@ -293,10 +293,28 @@ export default create({
       },
       next: () => {
         currentIndex.value += 1;
+        const nextDisabled = titles.value[currentIndex.value].disabled;
+        if (tabMethods.isEnd() && nextDisabled) {
+          tabMethods.prev();
+          return;
+        }
+        if (nextDisabled && currentIndex.value < titles.value.length - 1) {
+          tabMethods.next();
+          return;
+        }
         tabMethods.updateValue(titles.value[currentIndex.value]);
       },
       prev: () => {
         currentIndex.value -= 1;
+        const prevDisabled = titles.value[currentIndex.value].disabled;
+        if (tabMethods.isBegin() && prevDisabled) {
+          tabMethods.next();
+          return;
+        }
+        if (prevDisabled && currentIndex.value > 0) {
+          tabMethods.prev();
+          return;
+        }
         tabMethods.updateValue(titles.value[currentIndex.value]);
       },
       updateValue: (item: Title) => {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/jdf2e/nutui/issues/1671
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
修复tabs的子组件item设置disabled时，还能滑动到过去的问题(#2486)

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

**这个 PR 涉及以下平台:**

- [x] NutUI 4.0 H5
- [x] NutUI 4.0 小程序
- [ ] NutUI 3.0 H5
- [ ] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [ ] 自测 Vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/nutui4-vue/vite-ts)
- [ ] 自测 Taro 脚手架使用小程序 & Taro-H5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/nutui4-vue/taro)
