### PR TITLE
fix: 修复上传组件安卓环境下无法唤起摄像头问题

### DIFF
--- a/src/packages/__VUE/uploader/__tests__/index.spec.ts
+++ b/src/packages/__VUE/uploader/__tests__/index.spec.ts
@@ -28,9 +28,9 @@ test('should render base uploader props', async () => {
     }
   });
   const toast = wrapper.find('.nut-uploader__input');
-  expect(toast.attributes().capture).toBe('.jpg');
+  expect(toast.attributes().capture).toBe('camera');
   expect(toast.attributes().name).toBe('files');
-  expect(toast.attributes().accept).toBe('image/*');
+  expect(toast.attributes().accept).toBe('.jpg');
   expect(toast.exists()).toBe(true);
   toast.trigger('click');
   expect(wrapper.emitted('change'));

--- a/src/packages/__VUE/uploader/__tests__/index.spec.ts
+++ b/src/packages/__VUE/uploader/__tests__/index.spec.ts
@@ -28,7 +28,7 @@ test('should render base uploader props', async () => {
     }
   });
   const toast = wrapper.find('.nut-uploader__input');
-  expect(toast.attributes().capture).toBe('camera');
+  expect(toast.attributes().capture).toBe('.jpg');
   expect(toast.attributes().name).toBe('files');
   expect(toast.attributes().accept).toBe('image/*');
   expect(toast.exists()).toBe(true);

--- a/src/packages/__VUE/uploader/__tests__/index.spec.ts
+++ b/src/packages/__VUE/uploader/__tests__/index.spec.ts
@@ -30,7 +30,7 @@ test('should render base uploader props', async () => {
   const toast = wrapper.find('.nut-uploader__input');
   expect(toast.attributes().capture).toBe('camera');
   expect(toast.attributes().name).toBe('files');
-  expect(toast.attributes().accept).toBe('.jpg');
+  expect(toast.attributes().accept).toBe('image/*');
   expect(toast.exists()).toBe(true);
   toast.trigger('click');
   expect(wrapper.emitted('change'));

--- a/src/packages/__VUE/uploader/index.vue
+++ b/src/packages/__VUE/uploader/index.vue
@@ -159,7 +159,10 @@ export default create({
         disabled: props.disabled
       };
 
-      if (props.capture) params.capture = 'camera';
+      if (props.capture) {
+        params.capture = 'camera';
+        params.accept = 'image/*';
+      }
 
       return h('input', params);
     };

--- a/src/packages/__VUE/uploader/index.vue
+++ b/src/packages/__VUE/uploader/index.vue
@@ -161,7 +161,9 @@ export default create({
 
       if (props.capture) {
         params.capture = 'camera';
-        params.accept = 'image/*';
+        if (!params.accept) {
+          params.accept = 'image/*';
+        }
       }
 
       return h('input', params);


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/jdf2e/nutui/issues/1671
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

修复上传组件安卓环境下无法唤起摄像头问题

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

**这个 PR 涉及以下平台:**

- [x] NutUI 4.0 H5
- [ ] NutUI 4.0 小程序
- [ ] NutUI 3.0 H5
- [ ] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [x] 自测 Vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/nutui4-vue/vite-ts)
- [ ] 自测 Taro 脚手架使用小程序 & Taro-H5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/nutui4-vue/taro)
