### PR TITLE
Refactor/checkboxgroup

### DIFF
--- a/src/packages/checkboxgroup/checkboxgroup.vue
+++ b/src/packages/checkboxgroup/checkboxgroup.vue
@@ -1,6 +1,6 @@
 <template>
   <div :class="['nut-checkboxgroup', { vertical: vertical }, customClass]">
-    <div class="checkbox-item" v-for="(item, index) in checkBoxData" :key="item[keys.id]">
+    <div class="checkbox-item" v-for="(item, index) in list" :key="item[keys.id]">
       <nut-checkbox
         :name="name || item[keys.name]"
         :disabled="disabled || item[keys.disabled]"
@@ -9,7 +9,7 @@
         :size="item.size ? item.size : size"
         :id="item[keys.id]"
         :checked.sync="item.checked"
-        v-model="checkboxValues[item[keys.id]]"
+        :value="item.checked"
         @change="changeEvt(arguments, item)"
         >{{ item[keys.label] || item[keys.value] || item }}
       </nut-checkbox>
@@ -73,33 +73,22 @@ export default {
   data() {
     return {
       ignoreChange: false,
-      checkboxValues: {},
-      initialValue: [],
     };
   },
   components: {
     [nutcheckbox.name]: nutcheckbox,
   },
-  watch: {
-    value() {
-      this.init();
-    },
-    checkBoxData() {
-      this.init();
-    },
-  },
-  mounted() {
-    this.init();
-  },
-  methods: {
-    init() {
-      this.initialValue = this.value;
-      this.checkBoxData.map((item) => {
+  computed: {
+    list() {
+      return this.checkBoxData.map((item) => {
         if (typeof item === 'object') {
           item.checked = this.isOptionCheckedByDefault(item);
         }
+        return item;
       });
     },
+  },
+  methods: {
     isObject(obj) {
       return obj !== null && typeof obj === 'object';
     },
@@ -113,7 +102,7 @@ export default {
       return -1;
     },
     isOptionCheckedByDefault(item) {
-      return this.looseIndexOf(this.initialValue, item[this.keys.value] || item) > -1;
+      return this.looseIndexOf(this.value, item[this.keys.value] || item) > -1;
     },
     looseEqual(a, b) {
       return a == b || (this.isObject(a) && this.isObject(b) ? JSON.stringify(a) === JSON.stringify(b) : false);
@@ -153,19 +142,19 @@ export default {
         return;
       }
       if (checked === true) {
-        this.checkBoxData.map((item) => {
+        this.list.map((item) => {
           item.checked = true;
         });
       }
       if (!checked) {
-        this.checkBoxData.map((item) => {
+        this.list.map((item) => {
           item.checked = !item.checked;
         });
       }
 
       let value = [],
         label = [];
-      let resData = this.checkBoxData.filter((item) => {
+      let resData = this.list.filter((item) => {
         if (item.checked) {
           value.push(item.value);
           label.push(item.label);

--- a/src/packages/checkboxgroup/demo.vue
+++ b/src/packages/checkboxgroup/demo.vue
@@ -5,10 +5,18 @@
       <nut-cell>
         <span slot="title"><nut-checkboxgroup ref="checkboxGroup" :checkBoxData="data1" v-model="group1"></nut-checkboxgroup></span>
       </nut-cell>
-      <p>{{ group1 }}</p>
       <nut-button small @click="checkAll(true)">全选</nut-button>
       <nut-button small @click="checkAll(false)">取消全选</nut-button>
       <nut-button small @click="checkAll()">反选</nut-button>
+      <nut-button
+        small
+        @click="
+          data8 = data1;
+          data1 = [...data11];
+        "
+        >修改list</nut-button
+      >
+      <nut-button small @click="data1 = [...data8]">返回</nut-button>
     </div>
 
     <h4>禁用状态</h4>
@@ -84,34 +92,41 @@ export default {
         { id: 11, value: '选项A', label: '选项A' },
         { id: 12, value: '选项B', label: '选项B' },
         { id: 13, value: '选项C', label: '选项C' },
-        { id: 14, value: '选项D', label: '选项D' }
+        { id: 14, value: '选项D', label: '选项D' },
+      ],
+      data11: [
+        { id: 111, value: '选项A1', label: '选项A1' },
+        { id: 121, value: '选项B1', label: '选项B1' },
+        { id: 131, value: '选项C1', label: '选项C1' },
+        { id: 141, value: '选项D1', label: '选项D1' },
       ],
       data2: [
         { id: 21, value: '选项1', label: '选项1', disabled: true },
-        { id: 22, value: '选项2', label: '选项2', disabled: true }
+        { id: 22, value: '选项2', label: '选项2', disabled: true },
       ],
       data3: [{ id: 31, value: '备选项', label: '备选项' }],
       data33: [{ id: 31, value: '备选项', label: '备选项', size: 'large' }],
       data4: [
         { id: 41, value: '选项1', label: '选项1' },
-        { id: 42, value: '选项2', label: '选项2' }
+        { id: 42, value: '选项2', label: '选项2' },
       ],
       data5: [
         { id: 51, value: 'A', label: '选项1' },
         { id: 52, value: 'B', label: '选项2' },
         { id: 53, value: 'C', label: '选项3' },
-        { id: 54, value: 'D', label: '选项4' }
+        { id: 54, value: 'D', label: '选项4' },
       ],
       data6: [
         { id: 51, value: '选项1', label: '选项1' },
         { id: 52, value: '选项2', label: '选项2' },
         { id: 53, value: '选项3', label: '选项3' },
-        { id: 54, value: '选项4', label: '选项4' }
+        { id: 54, value: '选项4', label: '选项4' },
       ],
       data7: [
         { id: 41, value: '选项1', label: '选项1' },
-        { id: 42, value: '选项2', label: '选项2' }
-      ]
+        { id: 42, value: '选项2', label: '选项2' },
+      ],
+      data8: [],
     };
   },
   mounted() {
@@ -126,8 +141,8 @@ export default {
     },
     checkAll(state) {
       this.$refs.checkboxGroup.toggleAll(state);
-    }
-  }
+    },
+  },
 };
 </script>
 

--- a/src/packages/checkboxgroup/demo.vue
+++ b/src/packages/checkboxgroup/demo.vue
@@ -5,18 +5,10 @@
       <nut-cell>
         <span slot="title"><nut-checkboxgroup ref="checkboxGroup" :checkBoxData="data1" v-model="group1"></nut-checkboxgroup></span>
       </nut-cell>
+      <p>{{ group1 }}</p>
       <nut-button small @click="checkAll(true)">全选</nut-button>
       <nut-button small @click="checkAll(false)">取消全选</nut-button>
       <nut-button small @click="checkAll()">反选</nut-button>
-      <nut-button
-        small
-        @click="
-          data8 = data1;
-          data1 = [...data11];
-        "
-        >修改list</nut-button
-      >
-      <nut-button small @click="data1 = [...data8]">返回</nut-button>
     </div>
 
     <h4>禁用状态</h4>
@@ -94,12 +86,6 @@ export default {
         { id: 13, value: '选项C', label: '选项C' },
         { id: 14, value: '选项D', label: '选项D' },
       ],
-      data11: [
-        { id: 111, value: '选项A1', label: '选项A1' },
-        { id: 121, value: '选项B1', label: '选项B1' },
-        { id: 131, value: '选项C1', label: '选项C1' },
-        { id: 141, value: '选项D1', label: '选项D1' },
-      ],
       data2: [
         { id: 21, value: '选项1', label: '选项1', disabled: true },
         { id: 22, value: '选项2', label: '选项2', disabled: true },
@@ -126,7 +112,6 @@ export default {
         { id: 41, value: '选项1', label: '选项1' },
         { id: 42, value: '选项2', label: '选项2' },
       ],
-      data8: [],
     };
   },
   mounted() {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/jdf2e/nutui/issues/1671
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

重构了checkboxgroup的写法，历史逻辑中，render部分的不依赖组件的value，导致checkBoxData变化之后再去修改value的话VDOM并不会重新执行来更新checkbox的状态

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [x] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

**这个 PR 涉及以下平台:**

- [x] NutUI 2.0 H5
- [ ] NutUI 4.0 小程序
- [ ] NutUI 3.0 H5
- [ ] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [ ] 自测 Vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/nutui4-vue/vite-ts)
- [ ] 自测 Taro 脚手架使用小程序 & Taro-H5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/nutui4-vue/taro)

[问题复现示例](https://codesandbox.io/s/strange-khayyam-m2jlwm?file=/src/components/HelloWorld.vue)
