### PR TITLE
fix(imagepreview): 图片放大不能滑动(#2136)

### DIFF
--- a/src/packages/__VUE/imagepreview/index.vue
+++ b/src/packages/__VUE/imagepreview/index.vue
@@ -44,7 +44,7 @@
   </nut-popup>
 </template>
 <script lang="ts">
-import { toRefs, reactive, watch, onMounted, ref, computed } from 'vue';
+import { toRefs, reactive, watch, onMounted, ref, computed, nextTick } from 'vue';
 import type { PropType } from 'vue';
 import { createComponent } from '@/packages/utils/create';
 import { isArray } from '@/packages/utils/util';
@@ -148,7 +148,9 @@ export default create({
 
         if (val) {
           setActive(props.initNo);
-          init();
+          nextTick(() => {
+            init();
+          });
         }
       }
     );


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/jdf2e/nutui/issues/1671
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
图片放大不能滑动(#2136)
原因是未获取到元素宽度导致

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

**这个 PR 涉及以下平台:**

- [x] NutUI 4.0 H5
- [x] NutUI 4.0 小程序
- [ ] NutUI 3.0 H5
- [ ] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [ ] 自测 Vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/nutui4-vue/vite-ts)
- [ ] 自测 Taro 脚手架使用小程序 & Taro-H5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/nutui4-vue/taro)
