### PR TITLE
feat(collapse): 增加自定义插槽icon(#2588)

### DIFF
--- a/src/packages/__VUE/collapse/doc.en-US.md
+++ b/src/packages/__VUE/collapse/doc.en-US.md
@@ -212,6 +212,7 @@ Set content through slot: extra
 | title | Content slot on the left side of the title bar |
 | alue  | Right content slot of the title bar            |
 | extra | Set fixed content under the title (no folding) |
+| icon  | Set a custom icon                              |
 
 ### Events
 

--- a/src/packages/__VUE/collapse/doc.md
+++ b/src/packages/__VUE/collapse/doc.md
@@ -206,6 +206,7 @@ app.use(CollapseItem);
 | title | 标题栏左侧内容插槽           |
 | value | 标题栏右侧内容插槽           |
 | extra | 设置标题下固定内容（不折叠） |
+| icon  | 设置自定义图标               |
 
 ### Events
 

--- a/src/packages/__VUE/collapse/doc.taro.md
+++ b/src/packages/__VUE/collapse/doc.taro.md
@@ -206,6 +206,7 @@ app.use(CollapseItem);
 | title | 标题栏左侧内容插槽           |
 | value | 标题栏右侧内容插槽           |
 | extra | 设置标题下固定内容（不折叠） |
+| icon  | 设置自定义图标               |
 
 ### Events
 

--- a/src/packages/__VUE/collapseitem/index.taro.vue
+++ b/src/packages/__VUE/collapseitem/index.taro.vue
@@ -21,7 +21,8 @@
         :class="['nut-collapse-item__title-icon', { 'nut-collapse-item__title-icon--expanded': expanded }]"
         :style="{ transform: 'rotate(' + (expanded ? rotate : 0) + 'deg)' }"
       >
-        <component :is="renderIcon(icon)"></component>
+        <slot v-if="$slots.icon" name="icon"></slot>
+        <component :is="renderIcon(icon)" v-else></component>
       </view>
     </view>
 

--- a/src/packages/__VUE/collapseitem/index.vue
+++ b/src/packages/__VUE/collapseitem/index.vue
@@ -18,7 +18,8 @@
         :class="['nut-collapse-item__title-icon', { 'nut-collapse-item__title-icon--expanded': expanded }]"
         :style="{ transform: 'rotate(' + (expanded ? rotate : 0) + 'deg)' }"
       >
-        <component :is="renderIcon(icon)"></component>
+        <slot v-if="$slots.icon" name="icon"></slot>
+        <component :is="renderIcon(icon)" v-else></component>
       </view>
     </view>
 


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/jdf2e/nutui/issues/1671
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
collaps加自定义插槽icon

**这个 PR 是什么类型?** (至少选择一个)

- [x] 新特性提交
- [ ] 日常 bug 修复
- [x] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

**这个 PR 涉及以下平台:**

- [x] NutUI 4.0 H5
- [x] NutUI 4.0 小程序
- [ ] NutUI 3.0 H5
- [ ] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [ ] 自测 Vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/nutui4-vue/vite-ts)
- [ ] 自测 Taro 脚手架使用小程序 & Taro-H5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/nutui4-vue/taro)
