### PR TITLE
fix(swiper): 页面中其他元素设置 fixed，且未设置 z-index，无法覆盖 swiper

### DIFF
--- a/src/packages/__VUE/swiper/index.scss
+++ b/src/packages/__VUE/swiper/index.scss
@@ -1,6 +1,5 @@
 .nut-swiper {
   position: relative;
-  z-index: 1;
   display: flex;
   transition-property: transform;
   box-sizing: content-box;


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/jdf2e/nutui/issues/1671
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

**这个 PR 是什么类型?** (至少选择一个)

- [x] 日常 bug 修复

**这个 PR 涉及以下平台:**

- [x] NutUI 4.0 H5
- [x] NutUI 4.0 小程序


**这个 PR 是否已自测:**

- [ ] 自测 Vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/nutui4-vue/vite-ts)
- [ ] 自测 Taro 脚手架使用小程序 & Taro-H5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/nutui4-vue/taro)
