### PR TITLE
fix: ios真机中，只要radius设置的不是默认值，更新则会闪烁问题（#2481）

### DIFF
--- a/src/packages/__VUE/circleprogress/index.taro.vue
+++ b/src/packages/__VUE/circleprogress/index.taro.vue
@@ -10,6 +10,7 @@
 </template>
 
 <script lang="ts">
+import Taro from '@tarojs/taro';
 import { computed, ref, watch, PropType } from 'vue';
 import { createComponent } from '@/packages/utils/create';
 import { CircleProgressStrokeLinecap } from './types';
@@ -50,6 +51,7 @@ export default create({
     }
   },
   setup(props) {
+    const isIos = Taro.getSystemInfoSync().platform === 'ios';
     const currentRate = ref(props.progress);
     const refRandomId = Math.random().toString(36).slice(-8);
     const isObject = (val: unknown): val is Record<any, any> => val !== null && typeof val === 'object';
@@ -105,7 +107,7 @@ export default create({
         background: `url("data:image/svg+xml,%3Csvg viewBox='0 0 100 100'  xmlns='http://www.w3.org/2000/svg'%3E${pa}${path}${path1}%3C/svg%3E")`,
         width: '100%',
         height: '100%',
-        transition: ' background-image .3s ease 0s,stroke .3s ease 0s'
+        transition: `${isIos ? '' : 'background-image .3s ease 0s, '}stroke .3s ease 0s`
       };
     });
     const format = (progress: string | number) => Math.min(Math.max(+progress, 0), 100);


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/jdf2e/nutui/issues/1671
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
ios真机中，只要radius设置的不是默认值，更新则会闪烁问题（#2481）

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

**这个 PR 涉及以下平台:**

- [ ] NutUI 4.0 H5
- [x] NutUI 4.0 小程序
- [ ] NutUI 3.0 H5
- [ ] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [ ] 自测 Vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/nutui4-vue/vite-ts)
- [x] 自测 Taro 脚手架使用小程序 & Taro-H5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/nutui4-vue/taro)
