### PR TITLE
fix: 修复 inputnumber 组件的禁用功能无效问题

### DIFF
--- a/src/packages/__VUE/inputnumber/index.vue
+++ b/src/packages/__VUE/inputnumber/index.vue
@@ -106,6 +106,7 @@ export default create({
       return value > Number(props.min) && !props.disabled;
     };
     const reduce = (event: Event) => {
+      if (props.disabled) return;
       emit('reduce', event);
       let output_value = Number(props.modelValue) - Number(props.step);
       if (reduceAllow() && output_value >= Number(props.min)) {
@@ -116,6 +117,7 @@ export default create({
       }
     };
     const add = (event: Event) => {
+      if (props.disabled) return;
       emit('add', event);
       let output_value = Number(props.modelValue) + Number(props.step);
       if (addAllow() && output_value <= Number(props.max)) {


### PR DESCRIPTION
**这个 PR 做了什么?** (简要描述所做更改)
解决 inputnumber 组件在禁用状态下，点击‘+’、'-'按钮依然有效的问题

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

**这个 PR 涉及以下平台:**

- [x] NutUI 4.0 H5
- [x] NutUI 4.0 小程序
- [ ] NutUI 3.0 H5
- [ ] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [x] 自测 Vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/nutui4-vue/vite-ts)
- [ ] 自测 Taro 脚手架使用小程序 & Taro-H5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/nutui4-vue/taro)
