### PR TITLE
fix(textarea): 调整 readonly & maxlength 实现逻辑

### DIFF
--- a/packages/nutui-taro-demo/src/dentry/pages/textarea/index.vue
+++ b/packages/nutui-taro-demo/src/dentry/pages/textarea/index.vue
@@ -18,16 +18,3 @@ const value = ref('');
 const value2 = ref('');
 const value3 = ref('');
 </script>
-
-<style lang="scss">
-.nut-textarea__textarea__readonly {
-  background-color: #f9f9f9;
-}
-.nut-textarea--disabled {
-  textarea {
-    padding: 5px 10px;
-    height: 30px;
-    background-color: #f9f9f9;
-  }
-}
-</style>

--- a/src/packages/__VUE/textarea/doc.taro.md
+++ b/src/packages/__VUE/textarea/doc.taro.md
@@ -4,6 +4,8 @@
 
 文本框内输入或编辑文字，支持限制输入数量。
 
+推荐使用 Taro 提供的 Textarea 组件 [参考文档](https://taro-docs.jd.com/docs/components/forms/textarea)，多端兼容性更好。
+
 ### 安装
 
 ```js
@@ -79,26 +81,26 @@ const value = ref('');
 
 ### Props
 
-| 参数        | 说明                                                                                        | 类型                                                | 默认值   |
-| ----------- | ------------------------------------------------------------------------------------------- | --------------------------------------------------- | -------- |
-| v-model     | 输入值，支持双向绑定                                                                        | string                                              | -        |
-| placeholder | 设置占位提示文字                                                                            | string                                              | `请输入` |
-| max-length  | 限制最长输入字符                                                                            | string \| number                                    | -        |
-| rows        | textarea 的高度，优先级高于 autosize 属性 `仅支持 H5`                                       | string \| number                                    | `2`      |
-| limit-show  | textarea 是否展示输入字符。须配合`max-length`使用                                           | boolean                                             | `false`  |
-| autosize    | 是否自适应内容高度，也可传入对象, <br/> 如 `{ maxHeight: 200, minHeight: 100 }`，单位为`px` | boolean \| {maxHeight?: number; minHeight?: number} | `false`  |
-| text-align  | 文本位置,可选值`left`,`center`,`right`                                                      | string                                              | -        |
-| readonly    | 只读属性                                                                                    | boolean                                             | `false`  |
-| disabled    | 禁用属性                                                                                    | boolean                                             | `false`  |
-| autofocus   | 自动获取焦点                                                                                | boolean                                             | `false`  |
+| 参数 | 说明 | 类型 | 默认值 |
+| --- | --- | --- | --- |
+| v-model | 输入值，支持双向绑定 | string | - |
+| placeholder | 设置占位提示文字 | string | `请输入` |
+| max-length | 限制最长输入字符 | string \| number | - |
+| rows | textarea 的高度，优先级高于 autosize 属性 `仅支持 H5` | string \| number | `2` |
+| limit-show | textarea 是否展示输入字符。须配合`max-length`使用 | boolean | `false` |
+| autosize | 是否自适应内容高度，也可传入对象, <br/> 如 `{ maxHeight: 200, minHeight: 100 }`，单位为`px` | boolean \| {maxHeight?: number; minHeight?: number} | `false` |
+| text-align | 文本位置,可选值`left`,`center`,`right` | string | - |
+| readonly | 只读属性 | boolean | `false` |
+| disabled | 禁用属性 | boolean | `false` |
+| autofocus | 自动获取焦点 | boolean | `false` |
 
 ### Events
 
-| 事件名 | 说明               | 回调参数      |
-| ------ | ------------------ | ------------- |
-| change | 输入框值改变时触发 | `value`       |
-| focus  | 聚焦时触发         | `event`       |
-| blur   | 失焦时触发         | `value,event` |
+| 事件名 | 说明 | 回调参数 |
+| --- | --- | --- |
+| change | 输入框值改变时触发 | `value` |
+| focus | 聚焦时触发 | `event` |
+| blur | 失焦时触发 | `value,event` |
 
 ## 主题定制
 
@@ -106,9 +108,9 @@ const value = ref('');
 
 组件提供了下列 CSS 变量，可用于自定义样式，使用方法请参考 [ConfigProvider 组件](#/zh-CN/component/configprovider)。
 
-| 名称                          | 默认值                     |
-| ----------------------------- | -------------------------- |
-| --nut-textarea-font           | _var(--nut-font-size-2)_   |
-| --nut-textarea-limit-color    | _var(--nut-text-color)_    |
-| --nut-textarea-text-color     | _var(--nut-title-color)_   |
+| 名称 | 默认值 |
+| --- | --- |
+| --nut-textarea-font | _var(--nut-font-size-2)_ |
+| --nut-textarea-limit-color | _var(--nut-text-color)_ |
+| --nut-textarea-text-color | _var(--nut-title-color)_ |
 | --nut-textarea-disabled-color | _var(--nut-disable-color)_ |

--- a/src/packages/__VUE/textarea/index.scss
+++ b/src/packages/__VUE/textarea/index.scss
@@ -46,6 +46,7 @@
     line-height: 20px;
     .taro-textarea {
       font-size: 14px;
+      resize: none;
     }
   }
   &__textarea__readonly {

--- a/src/packages/__VUE/textarea/index.taro.vue
+++ b/src/packages/__VUE/textarea/index.taro.vue
@@ -1,22 +1,15 @@
 <template>
   <view :class="classes">
-    <rich-text
-      v-if="readonly && env !== 'WEB'"
-      class="nut-textarea__textarea nut-textarea__textarea__readonly"
-      :nodes="readonlyValue"
-    ></rich-text>
     <textarea
-      v-else
       ref="textareaRef"
       v-bind="$attrs"
       :class="['nut-textarea__textarea', env == 'ALIPAY' && 'nut-textarea__ali']"
       :style="styles"
       :rows="rows"
-      :disabled="disabled"
-      :readonly="readonly"
+      :disabled="disabled || readonly"
       :value="modelValue"
       :show-count="false"
-      :maxlength="maxLength"
+      :maxlength="maxLength ? maxLength : -1"
       :placeholder="placeholder || translate('placeholder')"
       :auto-focus="autofocus"
       @input="change"
@@ -30,7 +23,6 @@
     <view v-if="autosize" class="nut-textarea__cpoyText" :style="copyTxtStyle">{{ modelValue }}</view>
   </view>
 </template>
-<!-- eslint-disable @typescript-eslint/no-non-null-assertion -->
 <script lang="ts">
 import { computed, nextTick, onMounted, ref, watch } from 'vue';
 import { createComponent } from '@/packages/utils/create';
@@ -101,27 +93,19 @@ export default create({
       };
     });
 
-    const styles: any = computed(() => {
-      const styleObj: { textAlign: string; height?: string } = {
+    const styles = computed(() => {
+      const styleObj: any = {
         textAlign: props.textAlign
       };
       if (props.autosize) {
         styleObj['height'] = heightSet.value;
       }
       return styleObj;
-      // return {
-      //   textAlign: props.textAlign,
-      //   height: props.autosize ? heightSet.value : 'null'
-      // };
     });
 
     const copyTxtStyle: any = ref({
       'word-break': 'break-all',
       width: '0'
-    });
-
-    const readonlyValue = computed(() => {
-      return props.modelValue.replace(/\\n/g, '<br/>');
     });
 
     const emitChange = (value: string, event: Event) => {
@@ -140,8 +124,6 @@ export default create({
       } else {
         _onInput(event);
       }
-      // const input = event.target as HTMLInputElement;
-      // emitChange(input.value, event);
     };
     const _onInput = (event: Event) => {
       const input = event.target as HTMLInputElement;
@@ -173,9 +155,6 @@ export default create({
     const getContentHeight = () => {
       heightSet.value = 'auto';
       let height = textareaHeight.value;
-      // let textarea = textareaRef.value;
-      // textarea.style.height = 'auto';
-      // let height = textarea.scrollHeight;
       if (typeof props.autosize === 'object') {
         const { maxHeight, minHeight } = props.autosize;
         if (maxHeight !== undefined) {
@@ -186,7 +165,6 @@ export default create({
         }
       }
       if (height) {
-        // textarea.style.height = height + 'px';
         heightSet.value = height + 'px';
       }
     };
@@ -200,11 +178,6 @@ export default create({
         }
       }
     );
-    // const listenInput = () => {
-    // window.addEventListener('compositionend', function () {
-    //   copyHeight();
-    // });
-    // };
 
     const copyHeight = () => {
       const query = Taro.createSelectorQuery();
@@ -251,7 +224,6 @@ export default create({
     const env = Taro.getEnv();
     onMounted(() => {
       if (props.autosize) {
-        // listenInput();
         Taro.nextTick(() => {
           setTimeout(() => {
             if (Taro.getEnv() === 'ALIPAY' || Taro.getEnv() === 'WEB') {
@@ -268,7 +240,6 @@ export default create({
     const startComposing = () => {
       if (Taro.getEnv() === Taro.ENV_TYPE.WEB) {
         composing.value = true;
-        // (event.target as InputTarget)!.composing = true;
       }
     };
 
@@ -276,7 +247,6 @@ export default create({
       if (Taro.getEnv() === Taro.ENV_TYPE.WEB) {
         if (composing.value) {
           composing.value = false;
-          // (target as InputTarget)!.composing = false;
           (target as InputTarget).dispatchEvent(new Event('input'));
         }
       }
@@ -293,8 +263,7 @@ export default create({
       translate,
       copyTxtStyle,
       startComposing,
-      endComposing,
-      readonlyValue
+      endComposing
     };
   }
 });


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/jdf2e/nutui/issues/1671
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

1、移除 readonly 下的 rich-text
- 消除 h5 下的 vue 组件注册警告
- Taro 框架本身会将 textarea 标签的 readonly 映射为 disabled 属性，因此不再需要

2、修复 maxLength 的默认值导致的无法输入问题

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 新特性提交
- [x] 日常 bug 修复
- [x] 站点、文档改进
- [x] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

**这个 PR 涉及以下平台:**

- [ ] NutUI 4.0 H5
- [x] NutUI 4.0 小程序
- [ ] NutUI 3.0 H5
- [ ] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [ ] 自测 Vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/nutui4-vue/vite-ts)
- [x] 自测 Taro 脚手架使用小程序 & Taro-H5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/nutui4-vue/taro)
