### PR TITLE
fix(range, taro): 优化滑动事件处理逻辑

### DIFF
--- a/src/packages/__VUE/range/index.taro.vue
+++ b/src/packages/__VUE/range/index.taro.vue
@@ -56,14 +56,14 @@
             :aria-valuemax="+max"
             aria-orientation="horizontal"
             :catch-move="true"
-            @touchstart.stop.prevent="
+            @touchstart="
               (e) => {
                 onTouchStart(e);
               }
             "
-            @touchmove.stop.prevent="onTouchMove"
-            @touchend.stop.prevent="onTouchEnd"
-            @touchcancel.stop.prevent="onTouchEnd"
+            @touchmove="onTouchMove"
+            @touchend="onTouchEnd"
+            @touchcancel="onTouchEnd"
             @click="(e) => e.stopPropagation()"
           >
             <slot v-if="$slots.button" name="button"></slot>

--- a/src/packages/__VUE/range/index.taro.vue
+++ b/src/packages/__VUE/range/index.taro.vue
@@ -354,7 +354,7 @@ export default create({
 
       dragStatus.value = 'start';
       event.stopPropagation();
-      event.preventDefault();
+      if (event.cancelable) event.preventDefault();
     };
 
     // 初始化 range 宽高
@@ -373,7 +373,7 @@ export default create({
         return;
       }
       event.stopPropagation();
-      event.preventDefault();
+      if (event.cancelable) event.preventDefault();
       if (dragStatus.value === 'start') {
         emit('dragStart');
       }
@@ -406,7 +406,7 @@ export default create({
       }
       dragStatus.value = '';
       event.stopPropagation();
-      event.preventDefault();
+      if (event.cancelable) event.preventDefault();
     };
     const curValue = (idx?: number): number => {
       const value =

--- a/src/packages/__VUE/range/index.taro.vue
+++ b/src/packages/__VUE/range/index.taro.vue
@@ -26,7 +26,7 @@
             :aria-valuenow="curValue(index)"
             :aria-valuemax="+max"
             aria-orientation="horizontal"
-            @touchstart.stop.prevent="
+            @touchstart="
               (e) => {
                 if (typeof index === 'number') {
                   // 实时更新当前拖动的按钮索引
@@ -35,9 +35,9 @@
                 onTouchStart(e);
               }
             "
-            @touchmove.stop.prevent="onTouchMove"
-            @touchend.stop.prevent="onTouchEnd"
-            @touchcancel.stop.prevent="onTouchEnd"
+            @touchmove="onTouchMove"
+            @touchend="onTouchEnd"
+            @touchcancel="onTouchEnd"
             @click="(e) => e.stopPropagation()"
           >
             <slot v-if="$slots.button" name="button"></slot>
@@ -84,6 +84,7 @@ import { createComponent } from '@/packages/utils/create';
 import { useTouch } from '@/packages/utils/useTouch';
 import { useTaroRect } from '@/packages/utils/useTaroRect';
 import { SliderValue } from './type';
+import { preventDefault } from '@/packages/utils/util';
 const { componentName, create } = createComponent('range');
 
 export default create({
@@ -353,8 +354,7 @@ export default create({
       }
 
       dragStatus.value = 'start';
-      event.stopPropagation();
-      if (event.cancelable) event.preventDefault();
+      preventDefault(event, true);
     };
 
     // 初始化 range 宽高
@@ -372,8 +372,7 @@ export default create({
       if (props.disabled) {
         return;
       }
-      event.stopPropagation();
-      if (event.cancelable) event.preventDefault();
+      preventDefault(event, true);
       if (dragStatus.value === 'start') {
         emit('dragStart');
       }
@@ -405,8 +404,7 @@ export default create({
         emit('dragEnd');
       }
       dragStatus.value = '';
-      event.stopPropagation();
-      if (event.cancelable) event.preventDefault();
+      preventDefault(event, true);
     };
     const curValue = (idx?: number): number => {
       const value =

--- a/src/packages/__VUE/range/index.taro.vue
+++ b/src/packages/__VUE/range/index.taro.vue
@@ -305,6 +305,8 @@ export default create({
       const { min, modelValue } = props;
       useTaroRect(root).then(
         (rect: any) => {
+          state.value.width = rect.width;
+          state.value.height = rect.height;
           let clientX, clientY;
           if (Taro.getEnv() === Taro.ENV_TYPE.WEB) {
             clientX = event.clientX;

--- a/src/packages/__VUE/range/index.vue
+++ b/src/packages/__VUE/range/index.vue
@@ -362,7 +362,7 @@ export default create({
       }
       updateValue(currentValue);
       event.stopPropagation();
-      event.preventDefault();
+      if (event.cancelable) event.preventDefault();
     };
 
     const onTouchEnd = () => {

--- a/src/packages/__VUE/range/index.vue
+++ b/src/packages/__VUE/range/index.vue
@@ -361,8 +361,6 @@ export default create({
         currentValue = startValue + diff;
       }
       updateValue(currentValue);
-      event.stopPropagation();
-      if (event.cancelable) event.preventDefault();
     };
 
     const onTouchEnd = () => {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/jdf2e/nutui/issues/1671
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

获取用于计算的 range 尺寸信息
- 修改前：在每次 touch-move 时调用，异步操作，有可能会在 touch-end 回调之后执行，导致 change 事件无法触发
- 修改后：仅在 onReady 时获取一次尺寸信息，touch-move/end 回调内均为同步操作

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [x] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

**这个 PR 涉及以下平台:**

- [ ] NutUI 4.0 H5
- [x] NutUI 4.0 小程序
- [ ] NutUI 3.0 H5
- [ ] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [ ] 自测 Vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/nutui4-vue/vite-ts)
- [x] 自测 Taro 脚手架使用小程序 & Taro-H5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/nutui4-vue/taro)
