### PR TITLE
feat(tabs, taro): 开启 title-scroll 时不再需要设置 name

### DIFF
--- a/src/packages/__VUE/tabs/doc.md
+++ b/src/packages/__VUE/tabs/doc.md
@@ -84,8 +84,8 @@ app.use(TabPane);
 
 | 参数 | 说明 | 类型 | 默认值 |
 | --- | --- | --- | --- |
-| title | 标题 | string |  |
-| pane-key | 标签 Key , 匹配的标识符 | string | 默认索引 0,1,2... |
+| title | 标题 | string | - |
+| pane-key | 标签 Key , 匹配的标识符 | string | - |
 | disabled | 是否禁用标签 | boolean | false |
 
 ### TabPane Slots

--- a/src/packages/__VUE/tabs/doc.taro.md
+++ b/src/packages/__VUE/tabs/doc.taro.md
@@ -69,7 +69,7 @@ app.use(TabPane);
 | title-gutter | 标签间隙 | number \| string | `0` |
 | size | 标签栏字体尺寸大小 可选值 large normal small | string | `normal` |
 | auto-height | 自动高度。设置为 true 时，nut-tabs 和 nut-tabs\_\_content 会随着当前 nut-tab-pane 的高度而发生变化。 | boolean | `false` |
-| name | 在`taro`环境下，必须设置`name`以开启标题栏自动滚动功能。 | string | '' |
+| name `v4.2.5 废弃` | 必须设置 name 才能开启 title-scroll 功能，版本 >=4.2.5 时不再需要。 | string | '' |
 
 ### Tabs Slots
 
@@ -82,8 +82,8 @@ app.use(TabPane);
 
 | 参数 | 说明 | 类型 | 默认值 |
 | --- | --- | --- | --- |
-| title | 标题 | string |  |
-| pane-key | 标签 Key , 匹配的标识符 | string | 默认索引 0,1,2... |
+| title | 标题 | string | - |
+| pane-key | 标签 Key , 匹配的标识符 | string | - |
 | disabled | 是否禁用标签 | boolean | false |
 
 ### TabPane Slots

--- a/src/packages/__VUE/tabs/index.taro.vue
+++ b/src/packages/__VUE/tabs/index.taro.vue
@@ -1,7 +1,7 @@
 <template>
   <view ref="container" class="nut-tabs" :class="[direction]">
     <nut-scroll-view
-      :id="`nut-tabs__titles_${name}`"
+      :id="`nut-tabs__titles_${refRandomId}`"
       :scroll-x="getScrollX"
       :scroll-y="getScrollY"
       :scroll-with-animation="scrollWithAnimation"
@@ -143,15 +143,12 @@ export default create({
     top: {
       type: Number,
       default: 0
-    },
-    name: {
-      type: String,
-      default: ''
     }
   },
   emits: ['update:modelValue', 'click', 'change'],
 
   setup(props: any, { emit, slots }: any) {
+    const refRandomId = Math.random().toString(36).slice(-8);
     const container = ref(null);
     provide('tabsOpiton', {
       activeKey: computed(() => props.modelValue || '0'),
@@ -231,12 +228,10 @@ export default create({
     const titleRectRef = ref<RectItem[]>([]);
     const canShowLabel = ref(false);
     const scrollIntoView = () => {
-      if (!props.name) return;
-
       raf(() => {
         Promise.all([
-          getRect(`#nut-tabs__titles_${props.name}`),
-          getAllRect(`#nut-tabs__titles_${props.name} .nut-tabs__titles-item`)
+          getRect(`#nut-tabs__titles_${refRandomId}`),
+          getAllRect(`#nut-tabs__titles_${refRandomId} .nut-tabs__titles-item`)
         ]).then(([navRect, titleRects]: any) => {
           navRectRef.value = navRect;
           titleRectRef.value = titleRects;
@@ -399,7 +394,6 @@ export default create({
       }
       return { marginLeft: px, marginRight: px };
     });
-    const refRandomId = Math.random().toString(36).slice(-8);
     return {
       titles,
       tabsContentRef,

--- a/src/packages/__VUE/tabs/index.taro.vue
+++ b/src/packages/__VUE/tabs/index.taro.vue
@@ -238,15 +238,15 @@ export default create({
 
           if (navRectRef.value) {
             if (props.direction === 'vertical') {
-              const titlesTotalHeight = titleRects.reduce((prev: number, curr: RectItem) => prev + curr.height, 0);
-              if (titlesTotalHeight > navRectRef.value.height) {
+              const titlesTotalHeight = titleRects.reduce((prev: number, curr: RectItem) => prev + curr?.height, 0);
+              if (titlesTotalHeight > navRectRef.value?.height) {
                 canShowLabel.value = true;
               } else {
                 canShowLabel.value = false;
               }
             } else {
-              const titlesTotalWidth = titleRects.reduce((prev: number, curr: RectItem) => prev + curr.width, 0);
-              if (titlesTotalWidth > navRectRef.value.width) {
+              const titlesTotalWidth = titleRects.reduce((prev: number, curr: RectItem) => prev + curr?.width, 0);
+              if (titlesTotalWidth > navRectRef.value?.width) {
                 canShowLabel.value = true;
               } else {
                 canShowLabel.value = false;
@@ -261,14 +261,14 @@ export default create({
             const DEFAULT_PADDING = 11;
             const top = titleRects
               .slice(0, currentIndex.value)
-              .reduce((prev: number, curr: RectItem) => prev + curr.height + 0, DEFAULT_PADDING);
-            to = top - (navRectRef.value.height - titleRect.height) / 2;
+              .reduce((prev: number, curr: RectItem) => prev + curr?.height + 0, DEFAULT_PADDING);
+            to = top - (navRectRef.value?.height - titleRect?.height) / 2;
           } else {
             const DEFAULT_PADDING = 31;
             const left = titleRects
               .slice(0, currentIndex.value)
-              .reduce((prev: number, curr: RectItem) => prev + curr.width + 20, DEFAULT_PADDING);
-            to = left - (navRectRef.value.width - titleRect.width) / 2;
+              .reduce((prev: number, curr: RectItem) => prev + curr?.width + 20, DEFAULT_PADDING);
+            to = left - (navRectRef.value?.width - titleRect?.width) / 2;
           }
 
           nextTick(() => {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/jdf2e/nutui/issues/1671
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

**这个 PR 是什么类型?** (至少选择一个)

- [x] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

**这个 PR 涉及以下平台:**

- [ ] NutUI 4.0 H5
- [x] NutUI 4.0 小程序
- [ ] NutUI 3.0 H5
- [ ] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [ ] 自测 Vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/nutui4-vue/vite-ts)
- [x] 自测 Taro 脚手架使用小程序 & Taro-H5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/nutui4-vue/taro)
