### PR TITLE
fix(ellipsis): 修复taro端文本省略失效

### DIFF
--- a/src/packages/__VUE/ellipsis/index.taro.vue
+++ b/src/packages/__VUE/ellipsis/index.taro.vue
@@ -1,6 +1,6 @@
 <template>
   <view>
-    <view :id="'root' + refRandomId" ref="root" class="nut-ellipsis ell" @click="handleClick">
+    <view :id="rootId" class="nut-ellipsis ell" @click="handleClick">
       <view v-if="!exceeded" class="nut-ellipsis__wordbreak">{{ content }}</view>
 
       <view v-if="exceeded && !expanded" class="nut-ellipsis__wordbreak">
@@ -28,7 +28,7 @@
 </template>
 
 <script lang="ts">
-import { ref, reactive, toRefs, computed, onMounted, PropType, unref } from 'vue';
+import { ref, reactive, toRefs, computed, onMounted, PropType } from 'vue';
 import { createComponent } from '@/packages/utils/create';
 import { useTaroRect } from '@/packages/utils/useTaroRect';
 import Taro from '@tarojs/taro';
@@ -74,7 +74,6 @@ export default create({
   emits: ['click', 'change'],
 
   setup(props, { emit }) {
-    const root = ref(null);
     const rootContain = ref(null);
     const symbolContain = ref(null);
     let contantCopy = ref(props.content);
@@ -83,6 +82,7 @@ export default create({
     let originHeight = 0; // 原始高度
     const ellipsis = reactive<EllipsisedValue>({});
     const refRandomId = Math.random().toString(36).slice(-8);
+    const rootId = ref('root' + refRandomId);
     let widthRef = ref('auto');
     const state = reactive({
       exceeded: false, //是否超出
@@ -120,12 +120,10 @@ export default create({
     };
 
     const getReference = async () => {
-      let element = unref(root);
-
       const query = Taro.createSelectorQuery();
-      query.select(`#${(element as any).id}`) &&
+      query.select(`#${rootId.value}`) &&
         query
-          .select(`#${(element as any).id}`)
+          .select(`#${rootId.value}`)
           .fields(
             {
               computedStyle: ['width', 'height', 'lineHeight', 'paddingTop', 'paddingBottom', 'fontSize']
@@ -287,7 +285,7 @@ export default create({
 
     return {
       ...toRefs(state),
-      root,
+      rootId,
       rootContain,
       symbolContain,
       ellipsis,


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/jdf2e/nutui/issues/1671
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
修复taro端文本省略失效

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

**这个 PR 涉及以下平台:**

- [ ] NutUI 4.0 H5
- [x] NutUI 4.0 小程序
- [ ] NutUI 3.0 H5
- [ ] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [ ] 自测 Vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/nutui4-vue/vite-ts)
- [x] 自测 Taro 脚手架使用小程序 & Taro-H5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/nutui4-vue/taro)
