### PR TITLE
Revert "fix(textarea, taro): 修复 h5 下双向绑定失效的问题 (#2768)"

### DIFF
--- a/src/packages/__VUE/textarea/index.taro.vue
+++ b/src/packages/__VUE/textarea/index.taro.vue
@@ -127,8 +127,9 @@ export default create({
         _onInput(event);
       }
     };
-    const _onInput = (event: any) => {
-      let { value } = event.detail;
+    const _onInput = (event: Event) => {
+      const input = event.target as HTMLInputElement;
+      let value = input.value;
       if (props.maxLength && value.length > Number(props.maxLength)) {
         value = value.slice(0, Number(props.maxLength));
       }


### PR DESCRIPTION
这里存在一个难以解决的问题。参考 https://github.com/jdf2e/nutui/pull/2470

NutUI 发布的包代码是经过构建之后的 js 代码而非是 vue 模板源码，而 Taro 对于 H5 组件的转换在这个阶段之前。

This reverts commit 4c7d3467c37422420634de213443341b0411bce5.

<!--
请务必阅读贡献者指南:
https://github.com/jdf2e/nutui/issues/1671
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

**这个 PR 涉及以下平台:**

- [ ] NutUI 4.0 H5
- [ ] NutUI 4.0 小程序
- [ ] NutUI 3.0 H5
- [ ] NutUI 3.0 小程序

**这个 PR 是否已自测:**

- [ ] 自测 Vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/nutui4-vue/vite-ts)
- [ ] 自测 Taro 脚手架使用小程序 & Taro-H5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/nutui4-vue/taro)
