### PR TITLE
feat(inputnumber): 新增 type 属性，支持对value进行格式转换

### DIFF
--- a/src/packages/__VUE/inputnumber/doc.md
+++ b/src/packages/__VUE/inputnumber/doc.md
@@ -69,6 +69,7 @@ app.use(InputNumber);
 | button-size | 操作符+、-尺寸 | string | `` |
 | min | 最小值限制 | string \| number | `1` |
 | max | 最大值限制 | string \| number | `9999` |
+| type | 返回值格式设置 | string | `string` |
 | step | 步长 | string \| number | `1` |
 | decimal-places | 设置保留的小数位 | string \| number | `0` |
 | disabled | 禁用所有功能 | boolean | `false` |

--- a/src/packages/__VUE/inputnumber/doc.taro.md
+++ b/src/packages/__VUE/inputnumber/doc.taro.md
@@ -69,6 +69,7 @@ app.use(InputNumber);
 | button-size | 操作符+、-尺寸 | string | `` |
 | min | 最小值限制 | string \| number | `1` |
 | max | 最大值限制 | string \| number | `9999` |
+| type | 返回值格式设置 | string | `string` |
 | step | 步长 | string \| number | `1` |
 | decimal-places | 设置保留的小数位 | string \| number | `0` |
 | disabled | 禁用所有功能 | boolean | `false` |

--- a/src/packages/__VUE/inputnumber/index.taro.vue
+++ b/src/packages/__VUE/inputnumber/index.taro.vue
@@ -67,6 +67,10 @@ export default create({
       type: [Number, String],
       default: 9999
     },
+    type: {
+      type: String,
+      default: 'string'
+    },
     step: {
       type: [Number, String],
       default: 1
@@ -94,18 +98,25 @@ export default create({
         [`${prefixCls}--disabled`]: disabled.value
       };
     });
+    const formatValue = (val: string | number) => {
+      if (props.type === 'string') {
+        return val;
+      } else {
+        return Number(val);
+      }
+    };
     const fixedDecimalPlaces = (v: string | number): string => {
       return Number(v).toFixed(Number(props.decimalPlaces));
     };
     const change = (event: Event) => {
       const input = event.target as HTMLInputElement;
-      emit('update:modelValue', input.value, event);
-      emit('change', input.value, event);
+      emit('update:modelValue', formatValue(input.value), event);
+      emit('change', formatValue(input.value), event);
     };
     const emitChange = (value: string | number, event: Event) => {
       let output_value: number | string = fixedDecimalPlaces(value);
-      emit('update:modelValue', output_value, event);
-      if (Number(props.modelValue) !== Number(output_value)) emit('change', output_value, event);
+      emit('update:modelValue', formatValue(output_value), event);
+      if (Number(props.modelValue) !== Number(output_value)) emit('change', formatValue(output_value), event);
     };
     const addAllow = (value = Number(props.modelValue)): boolean => {
       return value < Number(props.max) && !disabled.value;

--- a/src/packages/__VUE/inputnumber/index.vue
+++ b/src/packages/__VUE/inputnumber/index.vue
@@ -62,6 +62,10 @@ export default create({
       type: [Number, String],
       default: 9999
     },
+    type: {
+      type: String,
+      default: 'string'
+    },
     step: {
       type: [Number, String],
       default: 1
@@ -89,18 +93,25 @@ export default create({
         [`${prefixCls}--disabled`]: disabled.value
       };
     });
+    const formatValue = (val: string | number) => {
+      if (props.type === 'string') {
+        return val;
+      } else {
+        return Number(val);
+      }
+    };
     const fixedDecimalPlaces = (v: string | number): string => {
       return Number(v).toFixed(Number(props.decimalPlaces));
     };
     const change = (event: Event) => {
       const input = event.target as HTMLInputElement;
-      emit('update:modelValue', input.value, event);
-      emit('change', input.value, event);
+      emit('update:modelValue', formatValue(input.value), event);
+      emit('change', formatValue(input.value), event);
     };
     const emitChange = (value: string | number, event: Event) => {
       let output_value: number | string = fixedDecimalPlaces(value);
-      emit('update:modelValue', output_value, event);
-      if (Number(props.modelValue) !== Number(output_value)) emit('change', output_value, event);
+      emit('update:modelValue', formatValue(output_value), event);
+      if (Number(props.modelValue) !== Number(output_value)) emit('change', formatValue(output_value), event);
     };
     const addAllow = (value = Number(props.modelValue)): boolean => {
       return value < Number(props.max) && !disabled.value;


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/jdf2e/nutui/issues/1671
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
更新前：inputnumber组件对v-module的值进行修改，不管传入的是string还是number类型，最终格式都会变成string类型。
更新后：给inputnumber增加了type选项，可选项为string|number，默认string。当type传入number后，inputnumber组件将格式化返回值为number类型。
**这个 PR 是什么类型?** (至少选择一个)

- [x] feat: 新特性提交
- [ ] fix: bug 修复
- [x] docs: 文档改进
- [ ] style: 组件样式/交互改进
- [ ] type: 类型定义更新
- [ ] perf: 性能、包体积优化
- [ ] refactor: 代码重构、代码风格优化
- [ ] test: 测试用例
- [ ] chore(deps): 依赖升级
- [ ] chore(demo): 演示代码改进
- [ ] chore(locale): 国际化改进
- [ ] chore: 其他改动（是关于什么的改动？）

**这个 PR 涉及以下平台:**

- [x] NutUI H5 @nutui/nutui
- [x] NutUI Taro @nutui/nutui-taro

**这个 PR 是否已自测:**

- [x] 自测 Vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/vite)
- [x] 自测 Taro 脚手架使用小程序 & Taro-H5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/taro)
