### PR TITLE
fix: cannot read properties of undefined (reading 'animatedTime')

### DIFF
--- a/src/packages/__VUE/tabpane/index.taro.vue
+++ b/src/packages/__VUE/tabpane/index.taro.vue
@@ -30,7 +30,7 @@ export default create({
     const paneStyle = computed(() => {
       return {
         display:
-          parentOption.animatedTime.value == 0 && props.paneKey != parentOption.activeKey.value ? 'none' : undefined
+          parentOption?.animatedTime.value == 0 && props.paneKey != parentOption?.activeKey.value ? 'none' : undefined
       } as CSSProperties
     })
     return {

--- a/src/packages/__VUE/tabpane/index.vue
+++ b/src/packages/__VUE/tabpane/index.vue
@@ -30,7 +30,7 @@ export default create({
     const paneStyle = computed(() => {
       return {
         display:
-          parentOption.animatedTime.value == 0 && props.paneKey != parentOption.activeKey.value ? 'none' : undefined
+          parentOption?.animatedTime.value == 0 && props.paneKey != parentOption?.activeKey.value ? 'none' : undefined
       } as CSSProperties
     })
     return {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/jdf2e/nutui/issues/1671
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
这个 PR 添加了对 inject 返回结果的空值判断，避免了 animatedTime、activeKey 读取错误。
**这个 PR 是什么类型?** (至少选择一个)

- [ ] feat: 新特性提交
- [x] fix: bug 修复
- [ ] docs: 文档改进
- [ ] style: 组件样式/交互改进
- [ ] type: 类型定义更新
- [ ] perf: 性能、包体积优化
- [ ] refactor: 代码重构、代码风格优化
- [ ] test: 测试用例
- [ ] chore(deps): 依赖升级
- [ ] chore(demo): 演示代码改进
- [ ] chore(locale): 国际化改进
- [ ] chore: 其他改动（是关于什么的改动？）

**这个 PR 涉及以下平台:**

- [x] NutUI H5 @nutui/nutui
- [x] NutUI Taro @nutui/nutui-taro

**这个 PR 是否已自测:**

- [ ] 自测 Vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/vite)
- [ ] 自测 Taro 脚手架使用小程序 & Taro-H5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/taro)
