### PR TITLE
fix(textarea): 修复 slot 嵌套使用 textarea 时的输入失焦问题

### DIFF
--- a/src/packages/__VUE/textarea/textarea.taro.vue
+++ b/src/packages/__VUE/textarea/textarea.taro.vue
@@ -11,7 +11,7 @@
       :show-count="false"
       :maxlength="maxLength ? maxLength : -1"
       :placeholder="placeholder || translate('placeholder')"
-      :auto-focus="autofocus"
+      :auto-focus="autofocus ? true : undefined"
       @input="change"
       @blur="blur"
       @focus="focus"


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/jdf2e/nutui/issues/1671
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

场景：textarea 的使用层级较深（即被多层组件包裹使用）时，输入会触发失去焦点，导致无法连续输入
代码：当 autofoucs 设置为 false 时，上述场景会被触发
解决办法：当 autofocus 为 true 时设置属性，否则不设置

历史提交：
https://github.com/jdf2e/nutui/commit/810cb85c161f33497470cb18d23e3f83866edb69
#2123

关联信息：
NutUI Taro 中的 Textarea 组件中使用的是 HTML 标签 textarea，会被 Taro 的插件 `@tarojs/plugin-html` 转换为小程序原生的 textarea，其中 auto-focus 属性会被映射为 focus

**这个 PR 是什么类型?** (至少选择一个)

- [ ] feat: 新特性提交
- [x] fix: bug 修复
- [ ] docs: 文档改进
- [ ] style: 组件样式/交互改进
- [ ] type: 类型定义更新
- [ ] perf: 性能、包体积优化
- [ ] refactor: 代码重构、代码风格优化
- [ ] test: 测试用例
- [ ] chore(deps): 依赖升级
- [ ] chore(demo): 演示代码改进
- [ ] chore(locale): 国际化改进
- [ ] chore: 其他改动（是关于什么的改动？）

**这个 PR 涉及以下平台:**

- [ ] NutUI H5 @nutui/nutui
- [x] NutUI Taro @nutui/nutui-taro

**这个 PR 是否已自测:**

- [ ] 自测 Vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/vite)
- [x] 自测 Taro 脚手架使用小程序 & Taro-H5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/taro)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **修复**
  - 修复了 `textarea` 组件中 `auto-focus` 属性的问题，现在会根据 `autofocus` 的值有条件地设置为 `true`。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->