### PR TITLE
修正参数名

### DIFF
--- a/src/packages/__VUE/input/doc.en-US.md
+++ b/src/packages/__VUE/input/doc.en-US.md
@@ -85,7 +85,7 @@ After setting the `maxlength` and `show-word-limit` attributes, word count will 
 | autofocus | Whether to auto focus, unsupported in iOS | boolean | `false` |
 | max-length | Max length of value | string ｜ number | - |
 | clearable | Whether to be clearable | boolean | `false` |
-| showClearIcon `4.0.2` | Whether to continue to display the clear button after losing focus, which will take effect when 'clearable' is set | boolean | `false` |
+| show-clear-icon `4.0.2` | Whether to continue to display the clear button after losing focus, which will take effect when 'clearable' is set | boolean | `false` |
 | clear-size | Clear Icon `font-size` | string | `14` |
 | show-word-limit | Whether to show word limit, need to set the `max-length` prop | boolean | `false` |
 | error | Whether to mark the input content in red | boolean | `false` |

--- a/src/packages/__VUE/input/doc.md
+++ b/src/packages/__VUE/input/doc.md
@@ -96,7 +96,7 @@ app.use(Input)
 | autofocus | 是否自动获得焦点，`iOS` 系统不支持该属性 | boolean | `false` |
 | max-length | 限制最长输入字符 | string ｜ number | - |
 | clearable | 展示清除 `Icon` | boolean | `false` |
-| showClearIcon `4.0.2` | 是否在失去焦点后，继续展示清除按钮，在设置 `clearable` 时生效 | boolean | `false` |
+| show-clear-icon `4.0.2` | 是否在失去焦点后，继续展示清除按钮，在设置 `clearable` 时生效 | boolean | `false` |
 | clear-size | 清除图标的 `font-size` 大小 | string | `14` |
 | show-word-limit | 是否显示限制最长输入字符，需要设置 `max-length` 属性 | boolean | `false` |
 | error | 是否标红 | boolean | `false` |

--- a/src/packages/__VUE/input/doc.taro.md
+++ b/src/packages/__VUE/input/doc.taro.md
@@ -100,7 +100,7 @@ app.use(Input)
 | autofocus | 是否自动获得焦点，`iOS` 系统不支持该属性 | boolean | `false` |
 | max-length | 限制最长输入字符 | string ｜ number | - |
 | clearable | 展示清除 `Icon` | boolean | `false` |
-| showClearIcon `4.0.2` | 是否在失去焦点后，继续展示清除按钮，在设置 `clearable` 时生效 | boolean | `false` |
+| show-clear-icon `4.0.2` | 是否在失去焦点后，继续展示清除按钮，在设置 `clearable` 时生效 | boolean | `false` |
 | clear-size | 清除图标的 `font-size` 大小 | string | `14` |
 | show-word-limit | 是否显示限制最长输入字符，需要设置 `max-length` 属性 | boolean | `false` |
 | error | 是否标红 | boolean | `false` |


### PR DESCRIPTION
更正参数名 showClearIcon 为show-clear-icon

<!--
请务必阅读贡献者指南:
https://github.com/jdf2e/nutui/issues/1671
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

**这个 PR 是什么类型?** (至少选择一个)

- [ ] feat: 新特性提交
- [ ] fix: bug 修复
- [x] docs: 文档改进
- [ ] style: 组件样式/交互改进
- [ ] type: 类型定义更新
- [ ] perf: 性能、包体积优化
- [ ] refactor: 代码重构、代码风格优化
- [ ] test: 测试用例
- [ ] chore(deps): 依赖升级
- [ ] chore(demo): 演示代码改进
- [ ] chore(locale): 国际化改进
- [ ] chore: 其他改动（是关于什么的改动？）

**这个 PR 涉及以下平台:**

- [x] NutUI H5 @nutui/nutui
- [ ] NutUI Taro @nutui/nutui-taro

**这个 PR 是否已自测:**

- [ ] 自测 Vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/vite)
- [ ] 自测 Taro 脚手架使用小程序 & Taro-H5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/taro)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **文档**
  - 将 `Input` 组件文档中的属性 `showClearIcon` 重命名为 `show-clear-icon`，以提高一致性和清晰度。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->