### PR TITLE
fix(calendarcard): 修复ios端设置disableDay不生效问题

### DIFF
--- a/packages/nutui-taro-demo/src/dentry/pages/calendarcard/disable.vue
+++ b/packages/nutui-taro-demo/src/dentry/pages/calendarcard/disable.vue
@@ -9,7 +9,7 @@ const onChange = (val: Date) => {
   console.log(val)
 }
 const disableDay = (day: CalendarCardDay) => {
-  const d = new Date(`${day.year}-${day.month}-${day.date}`).getDay()
+  const d = new Date(`${day.year}/${day.month}/${day.date}`).getDay()
   return d === 1 || d === 3
 }
 </script>

--- a/src/packages/__VUE/calendarcard/demo/disable.vue
+++ b/src/packages/__VUE/calendarcard/demo/disable.vue
@@ -9,7 +9,7 @@ const onChange = (val: Date) => {
   console.log(val)
 }
 const disableDay = (day: CalendarCardDay) => {
-  const d = new Date(`${day.year}-${day.month}-${day.date}`).getDay()
+  const d = new Date(`${day.year}/${day.month}/${day.date}`).getDay()
   return d === 1 || d === 3
 }
 </script>


### PR DESCRIPTION
#3121 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **修复**
  - 修复了 `CalendarCard` 组件中日期格式的错误，现在使用正斜杠 `/` 而不是连字符 `-` 来构造日期对象。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->