### PR TITLE
fix: 修复 range-component 在百度小程序下点击获取元素位置信息报错

### DIFF
--- a/src/packages/__VUE/range/index.taro.vue
+++ b/src/packages/__VUE/range/index.taro.vue
@@ -311,13 +311,21 @@ export default create({
           state.value.width = rect.width
           state.value.height = rect.height
           let clientX, clientY
-          if (Taro.getEnv() === Taro.ENV_TYPE.WEB) {
-            clientX = event.clientX
-            clientY = event.clientY
-          } else {
-            clientX = event.touches[0].clientX
-            clientY = event.touches[0].clientY
+
+          switch (Taro.getEnv()) {
+            case Taro.ENV_TYPE.WEB:
+              clientX = event.clientX
+              clientY = event.clientY
+              break
+            case Taro.ENV_TYPE.SWAN:
+              clientX = event.changedTouches[0].clientX
+              clientY = event.changedTouches[0].clientY
+              break
+            default:
+              clientX = event.touches[0].clientX
+              clientY = event.touches[0].clientY
           }
+
           let delta = clientX - rect.left
           let total = rect.width
           if (props.vertical) {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/jdf2e/nutui/issues/1671
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

这个 PR 修复了 range 组件在百度小程序下点击报错的问题的兼容处理，在百度小程序环境中，`click` 事件（也就是编译后的 `tap` 事件）无法直接从 `touches`  属性获取元素的位置信息。

![image](https://github.com/jdf2e/nutui/assets/37327614/ffb38bee-a78a-4663-a6bc-c57f2cec4103)

**这个 PR 是什么类型?** (至少选择一个)

- [ ] feat: 新特性提交
- [x] fix: bug 修复
- [ ] docs: 文档改进
- [ ] style: 组件样式/交互改进
- [ ] type: 类型定义更新
- [ ] perf: 性能、包体积优化
- [ ] refactor: 代码重构、代码风格优化
- [ ] test: 测试用例
- [ ] chore(deps): 依赖升级
- [ ] chore(demo): 演示代码改进
- [ ] chore(locale): 国际化改进
- [ ] chore: 其他改动（是关于什么的改动？）

**这个 PR 涉及以下平台:**

- [ ] NutUI H5 @nutui/nutui
- [x] NutUI Taro @nutui/nutui-taro

**这个 PR 是否已自测:**

- [ ] 自测 Vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/vite)
- [x] 自测 Taro 脚手架使用小程序 & Taro-H5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/taro)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 更新了事件处理逻辑以适应不同的环境类型（Taro.ENV_TYPE.WEB, Taro.ENV_TYPE.SWAN, 默认情况），确保在不同环境下正确设置 `clientX` 和 `clientY` 值。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->