### PR TITLE
feat(picker): 为当前选中的 picker-roller-item 新增类名

### DIFF
--- a/src/packages/__VUE/picker/Column.vue
+++ b/src/packages/__VUE/picker/Column.vue
@@ -24,7 +24,8 @@
           v-if="item && item[fieldNames.text] && !threeDimensional"
           class="nut-picker-roller-item-tile"
           :class="{
-            [item[fieldNames.className]]: item[fieldNames.className]
+            [item[fieldNames.className]]: item[fieldNames.className],
+            'nut-picker-roller-item-selected': isCurrPick(index + 1)
           }"
           :style="{ height: pxCheck(optionHeight), lineHeight: pxCheck(optionHeight) }"
         >
@@ -217,6 +218,10 @@ export default create({
       }
     }
 
+    const isCurrPick = (index: number) => {
+      return index == state.currIndex
+    }
+
     const setTransform = (translateY = 0, type: string | null, time = DEFAULT_DURATION, deg: string | number) => {
       if (type === 'end') {
         touchTime.value = time
@@ -318,6 +323,7 @@ export default create({
       ...toRefs(props),
       setRollerStyle,
       isHidden,
+      isCurrPick,
       roller,
       onTouchStart,
       onTouchMove,


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/jdf2e/nutui/issues/1671
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

为 Picker 组件备选项中的当前选中项新增 `nut-picker-roller-item-selected` 类名，便于为当前项配置自定义样式

**这个 PR 是什么类型?** (至少选择一个)

- [x] feat: 新特性提交
- [ ] fix: bug 修复
- [ ] docs: 文档改进
- [x] style: 组件样式/交互改进
- [ ] type: 类型定义更新
- [ ] perf: 性能、包体积优化
- [ ] refactor: 代码重构、代码风格优化
- [ ] test: 测试用例
- [ ] chore(deps): 依赖升级
- [ ] chore(demo): 演示代码改进
- [ ] chore(locale): 国际化改进
- [ ] chore: 其他改动（是关于什么的改动？）

**这个 PR 涉及以下平台:**

- [x] NutUI H5 @nutui/nutui
- [ ] NutUI Taro @nutui/nutui-taro

**这个 PR 是否已自测:**

- [x] 自测 Vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/vite)
- [ ] 自测 Taro 脚手架使用小程序 & Taro-H5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/taro)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 添加了选择功能，通过当前索引来高亮显示选择项。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->