### PR TITLE
perf: 优化 empty 组件判断 image 是否为一个有效的资源链接

### DIFF
--- a/src/packages/__VUE/empty/empty.taro.vue
+++ b/src/packages/__VUE/empty/empty.taro.vue
@@ -58,15 +58,7 @@ const style = computed(() => {
   return {}
 })
 
-const src = computed(() => {
-  if (props.image.startsWith('https://') || props.image.startsWith('http://') || props.image.startsWith('//')) {
-    return props.image
-  } else {
-    return defaultStatus[props.image]
-  }
-})
+const src = computed(() => /^https?:\/\/|^\/\//.test(props.image) ? props.image : defaultStatus[props.image])
 
-const descriptionText = computed(() => {
-  return props.description || translate('noData')
-})
+const descriptionText = computed(() => props.description || translate('noData'))
 </script>

--- a/src/packages/__VUE/empty/empty.vue
+++ b/src/packages/__VUE/empty/empty.vue
@@ -58,15 +58,7 @@ const style = computed(() => {
   return {}
 })
 
-const src = computed(() => {
-  if (props.image.startsWith('https://') || props.image.startsWith('http://') || props.image.startsWith('//')) {
-    return props.image
-  } else {
-    return defaultStatus[props.image]
-  }
-})
+const src = computed(() => /^https?:\/\/|^\/\//.test(props.image) ? props.image : defaultStatus[props.image])
 
-const descriptionText = computed(() => {
-  return props.description || translate('noData')
-})
+const descriptionText = computed(() => props.description || translate('noData'))
 </script>


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/jdf2e/nutui/issues/1671
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

简化了判断 `image` 属性是否为一个有效的 URL 资源链接

**这个 PR 是什么类型?** (至少选择一个)

- [ ] feat: 新特性提交
- [ ] fix: bug 修复
- [ ] docs: 文档改进
- [ ] style: 组件样式/交互改进
- [ ] type: 类型定义更新
- [x] perf: 性能、包体积优化
- [ ] refactor: 代码重构、代码风格优化
- [ ] test: 测试用例
- [ ] chore(deps): 依赖升级
- [ ] chore(demo): 演示代码改进
- [ ] chore(locale): 国际化改进
- [ ] chore: 其他改动（是关于什么的改动？）

**这个 PR 涉及以下平台:**

- [x] NutUI H5 @nutui/nutui
- [x] NutUI Taro @nutui/nutui-taro

**这个 PR 是否已自测:**

- [ ] 自测 Vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/vite)
- [x] 自测 Taro 脚手架使用小程序 & Taro-H5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/taro)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **功能改进**
  - 优化了 `src` 和 `descriptionText` 的计算逻辑，更高效地处理图片 URL 和描述信息。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->