### PR TITLE
bugfix: add 'transform: translate(0)' to .nut-tab-pane

### DIFF
--- a/src/packages/__VUE/tabpane/index.scss
+++ b/src/packages/__VUE/tabpane/index.scss
@@ -13,6 +13,7 @@
   overflow: auto;
   height: 100%;
   word-break: break-all;
+  transform: translate(0);
   &.inactive {
     overflow: visible;
     height: 0;


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/jdf2e/nutui/issues/1671
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** 

修复tab-container顶层容器使用transform移动时，tab内部的fixed属性失效，导致布局错误的情况。

**这个 PR 是什么类型?** 

- [ ☑️] fix: bug 修复

**这个 PR 涉及以下平台:**

- [ ☑️] NutUI H5 @nutui/nutui

**这个 PR 是否已自测:**

- [ ] 自测 Vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/vite)
- [ ] 自测 Taro 脚手架使用小程序 & Taro-H5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/taro)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **样式**
  - 为 TabPane 元素添加了 `transform: translate(0);` 样式属性。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->