### PR TITLE
perf: 优化 popover 显隐过渡效果

### DIFF
--- a/src/packages/__VUE/popover/index.scss
+++ b/src/packages/__VUE/popover/index.scss
@@ -109,7 +109,7 @@
 
     &-enter-from,
     &-leave-to {
-      transform: scale(0.8);
+      transform: scale(var(--transform-scale));
       opacity: 0;
     }
 

--- a/src/packages/__VUE/popover/index.scss
+++ b/src/packages/__VUE/popover/index.scss
@@ -103,9 +103,19 @@
 
     &-group {
       display: block;
-      // position: relative;
       height: 100%;
       width: 100%;
+    }
+
+    &-enter-from,
+    &-leave-to {
+      transform: scale(0.8);
+      opacity: 0;
+    }
+
+    &-enter-active,
+    &-leave-active {
+      transition-timing-function: ease;
     }
 
     .nut-popover-menu-item {
@@ -224,20 +234,6 @@
       }
     }
   }
-}
-
-.nut-popover-enter-from,
-.nut-popover-leave-active {
-  transform: scale(0.8);
-  opacity: 0;
-}
-
-.nut-popover-enter-active {
-  transition-timing-function: ease-out;
-}
-
-.nut-popover-leave-active {
-  transition-timing-function: ease-in;
 }
 
 .nut-popover-content-bg {

--- a/src/packages/__VUE/popover/index.taro.vue
+++ b/src/packages/__VUE/popover/index.taro.vue
@@ -238,7 +238,7 @@ export default create({
 
     watch(
       () => props.visible,
-      async (value) => {
+      (value) => {
         showPopup.value = value
         if (value) nextTick(() => getContentWidth())
       }

--- a/src/packages/__VUE/popover/index.taro.vue
+++ b/src/packages/__VUE/popover/index.taro.vue
@@ -12,7 +12,7 @@
     <nut-popup
       v-model:visible="showPopup"
       :pop-class="`nut-popover-content nut-popover-content--${location}`"
-      :style="{ background: bgColor }"
+      :style="{ background: bgColor, '--transform-scale': DEFAULT_SCALE_TRANSITION }"
       position=""
       transition="nut-popover-content"
       :overlay="overlay"
@@ -77,6 +77,8 @@ export default create({
     const showPopup = ref(props.visible)
 
     const rootPosition = ref<PopoverRootPosition>()
+
+    const DEFAULT_SCALE_TRANSITION = 0.8
 
     const elRect = ref({
       width: 0,
@@ -194,8 +196,8 @@ export default create({
       try {
         const rect = await useTaroRect(popoverContentRef)
         elRect.value = {
-          height: rect.height,
-          width: rect.width
+          height: rect.height / DEFAULT_SCALE_TRANSITION,
+          width: rect.width / DEFAULT_SCALE_TRANSITION
         }
       } catch (error) {
         console.warn('[NutUI] Failed to get rect:', error)
@@ -286,7 +288,8 @@ export default create({
       popoverArrowStyle,
       renderIcon,
       refRandomId,
-      clickAway
+      clickAway,
+      DEFAULT_SCALE_TRANSITION
     }
   }
 })

--- a/src/packages/__VUE/popover/index.taro.vue
+++ b/src/packages/__VUE/popover/index.taro.vue
@@ -6,8 +6,7 @@
     class="nut-popover-wrapper"
     @click="openPopover"
   >
-    <slot name="reference"></slot
-    >
+    <slot name="reference"></slot>
   </view>
   <view :class="['nut-popover', `nut-popover--${theme}`, `${customClass}`]" :style="getRootPosition">
     <nut-popup
@@ -15,7 +14,7 @@
       :pop-class="`nut-popover-content nut-popover-content--${location}`"
       :style="{ background: bgColor }"
       position=""
-      transition="nut-popover"
+      transition="nut-popover-content"
       :overlay="overlay"
       :duration="duration"
       :overlay-style="overlayStyle"
@@ -41,9 +40,9 @@
   </view>
 </template>
 <script lang="ts">
-import { onMounted, computed, watch, ref, PropType, CSSProperties } from 'vue'
+import { onMounted, computed, watch, ref, PropType, CSSProperties, nextTick } from 'vue'
 import { createComponent, renderIcon } from '@/packages/utils/create'
-import { useTaroRect, useTaroRectById } from '@/packages/utils/useTaroRect'
+import { rectTaro, useTaroRect, useTaroRectById } from '@/packages/utils/useTaroRect'
 import { PopoverList, PopoverTheme, PopoverLocation, PopoverRootPosition } from './type'
 import NutPopup from '../popup/index.taro.vue'
 import Taro from '@tarojs/taro'
@@ -131,9 +130,7 @@ export default create({
     })
 
     const upperCaseFirst = (str: string) => {
-      str = str.toLowerCase()
-      str = str.replace(/\b\w+\b/g, word => word.substring(0, 1).toUpperCase() + word.substring(1))
-      return str
+      return str.toLowerCase().replace(/\b\w+\b/g, word => word.substring(0, 1).toUpperCase() + word.substring(1))
     }
 
     const getRootPosition = computed(() => {
@@ -194,73 +191,56 @@ export default create({
     })
 
     const getPopoverContentW = async () => {
-      useTaroRect(popoverContentRef).then(
-        (rect: { width: number, height: number }) => {
-          elRect.value = {
-            height: rect.height,
-            width: rect.width
-          }
-        },
-        () => {}
-      )
+      try {
+        const rect = await useTaroRect(popoverContentRef)
+        elRect.value = {
+          height: rect.height,
+          width: rect.width
+        }
+      } catch (error) {
+        console.warn('[NutUI] Failed to get rect:', error)
+      }
     }
 
     // 获取宽度
-    const getContentWidth = () => {
+    const getContentWidth = async () => {
+      getPopoverContentW()
       Taro.createSelectorQuery()
         .selectViewport()
-        .scrollOffset((res) => {
-          const distance = res.scrollTop
-
+        .scrollOffset(async (result) => {
+          const distance = result.scrollTop
           if (props.targetId) {
-            useTaroRectById(props.targetId).then(
-              (rect: any) => {
-                rootPosition.value = {
-                  width: rect?.width,
-                  height: rect?.height,
-                  left: rect?.left,
-                  top: rect?.top + distance,
-                  right: rect?.right
-                }
-              },
-              () => {}
-            )
+            const rect = (await useTaroRectById(props.targetId)) as rectTaro
+            rootPosition.value = {
+              width: rect?.width,
+              height: rect?.height,
+              left: rect?.left,
+              top: rect?.top + distance,
+              right: rect?.right
+            }
           } else {
-            useTaroRect(popoverRef).then(
-              (rect: any) => {
-                rootPosition.value = {
-                  width: rect?.width,
-                  height: rect?.height,
-                  left: rect?.left,
-                  top: rect?.top + distance,
-                  right: rect?.right
-                }
-              },
-              () => {}
-            )
+            const rect = await useTaroRect(popoverRef)
+            rootPosition.value = {
+              width: rect?.width,
+              height: rect?.height,
+              left: rect?.left,
+              top: rect?.top + distance,
+              right: rect?.right
+            }
           }
         })
         .exec()
-      setTimeout(() => {
-        getPopoverContentW()
-      }, 300)
     }
 
     onMounted(() => {
-      setTimeout(() => {
-        getContentWidth()
-      }, 300)
+      getContentWidth()
     })
 
     watch(
       () => props.visible,
-      (value) => {
+      async (value) => {
         showPopup.value = value
-        if (value) {
-          Taro.nextTick(() => {
-            getContentWidth()
-          })
-        }
+        if (value) nextTick(() => getContentWidth())
       }
     )
 

--- a/src/packages/__VUE/popover/index.vue
+++ b/src/packages/__VUE/popover/index.vue
@@ -7,9 +7,9 @@
       <nut-popup
         v-model:visible="showPopup"
         :pop-class="`nut-popover-content nut-popover-content--${location}`"
-        :style="{ background: bgColor }"
+        :style="{ background: bgColor, '--transform-scale': DEFAULT_SCALE_TRANSITION }"
         position=""
-        transition="nut-popover"
+        transition="nut-popover-content"
         :overlay="overlay"
         :duration="duration"
         :overlay-style="overlayStyle"
@@ -71,6 +71,8 @@ export default create({
 
     const rootPosition = ref<PopoverRootPosition>()
 
+    const DEFAULT_SCALE_TRANSITION = 0.8
+
     const elRect = ref({
       width: 0,
       height: 0
@@ -130,7 +132,10 @@ export default create({
 
     const getRootPosition = computed(() => {
       const styles: CSSProperties = {}
-      if (!rootPosition.value) return {}
+      if (!rootPosition.value) {
+        styles.visibility = 'hidden'
+        return styles
+      }
 
       const contentWidth = elRect.value.width
       const contentHeight = elRect.value.height
@@ -174,6 +179,11 @@ export default create({
         }
       }
 
+      if (elRect.value.width === 0) {
+        styles.visibility = 'hidden'
+      } else {
+        styles.visibility = 'initial'
+      }
       return styles
     })
 
@@ -258,7 +268,8 @@ export default create({
       popoverContentRef,
       getRootPosition,
       popoverArrowStyle,
-      renderIcon
+      renderIcon,
+      DEFAULT_SCALE_TRANSITION
     }
   }
 })


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/jdf2e/nutui/issues/1671
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

`<popover />` 组件第一次渲染，会有很明显的延时，并且显隐过渡动画有顿挫感，此 PR 修复了这个问题。

修复前：

[NutUI - 移动端 Vue 小程序组件库.webm](https://github.com/user-attachments/assets/c5f341db-0fe4-4d4f-8e1a-9b68f3a92ef3)

修复后：

https://github.com/user-attachments/assets/05672cb4-1095-4afb-8d78-08446ffade83



**这个 PR 是什么类型?** (至少选择一个)

- [ ] feat: 新特性提交
- [ ] fix: bug 修复
- [ ] docs: 文档改进
- [x] style: 组件样式/交互改进
- [ ] type: 类型定义更新
- [ ] perf: 性能、包体积优化
- [ ] refactor: 代码重构、代码风格优化
- [ ] test: 测试用例
- [ ] chore(deps): 依赖升级
- [ ] chore(demo): 演示代码改进
- [ ] chore(locale): 国际化改进
- [ ] chore: 其他改动（是关于什么的改动？）

**这个 PR 涉及以下平台:**

- [x] NutUI H5 @nutui/nutui
- [x] NutUI Taro @nutui/nutui-taro

**这个 PR 是否已自测:**

- [ ] 自测 Vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/vite)
- [x] 自测 Taro 脚手架使用小程序 & Taro-H5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/taro)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 更新了弹出框的过渡动画效果，使得弹出和消失的动画更加平滑自然。

- **错误修复**
  - 修正了 `<slot>` 元素中缺失的闭合标签。
  - 修改了 `transition` 属性值，以确保弹出内容的动画效果。

- **重构**
  - 优化了函数命名，以提高代码可读性。
  - 使用 async/await 改写了部分函数，增强了错误处理和代码简洁性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->