### PR TITLE
Fix a typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@
 | [@nutui/icons-vue](https://github.com/jdf2e/nutui-icons) | `@nutui/nutui` 使用的图标库 | ![nutui](https://img.shields.io/npm/v/@nutui/icons-vue.svg?label=%20) |
 | [@nutui/icons-vue-taro](https://github.com/jdf2e/nutui-icons) | `@nutui/nutui-taro` 使用的图标库 | ![nutui](https://img.shields.io/npm/v/@nutui/icons-vue-taro.svg?label=%20) |
 | [@nutui/touch-emulator](packages/nutui-touch-emulator) | 在桌面端使用 NutUI 的辅助库 | ![nutui](https://img.shields.io/npm/v/@nutui/touch-emulator.svg?label=%20) |
-| [@nutui/auto-import-resolver](packages/nutui-auto-import-resolver) | `unplugin-auto-import` 插件的 reolver 配置 | ![nutui](https://img.shields.io/npm/v/@nutui/auto-import-resolver.svg?label=%20) |
+| [@nutui/auto-import-resolver](packages/nutui-auto-import-resolver) | `unplugin-auto-import` 插件的 resolver 配置 | ![nutui](https://img.shields.io/npm/v/@nutui/auto-import-resolver.svg?label=%20) |
 | [@nutui/playground](packages/nutui-playground) | NutUI 在线 Playground | - |
 | [nutui-demo](https://github.com/jdf2e/nutui-demo) | NutUI 官方示例合集 | - |
 


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/jdf2e/nutui/issues/1671
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

**这个 PR 是什么类型?** (至少选择一个)

- [ ] feat: 新特性提交
- [ ] fix: bug 修复
- [x] docs: 文档改进
- [ ] style: 组件样式/交互改进
- [ ] type: 类型定义更新
- [ ] perf: 性能、包体积优化
- [ ] refactor: 代码重构、代码风格优化
- [ ] test: 测试用例
- [ ] chore(deps): 依赖升级
- [ ] chore(demo): 演示代码改进
- [ ] chore(locale): 国际化改进
- [ ] chore: 其他改动（是关于什么的改动？）

**这个 PR 涉及以下平台:**

- [ ] NutUI H5 @nutui/nutui
- [ ] NutUI Taro @nutui/nutui-taro

**这个 PR 是否已自测:**

- [ ] 自测 Vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/vite)
- [ ] 自测 Taro 脚手架使用小程序 & Taro-H5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/taro)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **文档**
	- 修正了 `README.md` 文件中关于 `@nutui/auto-import-resolver` 包的描述，将“reolver”更正为“resolver”，提升了文档的清晰度和准确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->