### PR TITLE
fix(uploader): 修复data外部修改后提交时依然是旧值问题

### DIFF
--- a/src/packages/__VUE/uploader/doc.en-US.md
+++ b/src/packages/__VUE/uploader/doc.en-US.md
@@ -366,8 +366,8 @@ const clearUpload = () => {
 | name | File name | - |
 | url | File path | - |
 | type | File type | `"image/jpeg" ` |
-| formData | Upload the required data | `new FormData()` |
 | percentage | Upload percentage | `0` |
+| sourceFile | Upload the required file | - |
 
 ### Events
 

--- a/src/packages/__VUE/uploader/doc.md
+++ b/src/packages/__VUE/uploader/doc.md
@@ -367,8 +367,8 @@ const clearUpload = () => {
 | name | 文件名称 | - |
 | url | 文件路径 | - |
 | type | 文件类型 | `"image/jpeg"` |
-| formData | 上传所需的 data | `new FormData() ` |
 | percentage | 上传百分比 | `0` |
+| sourceFile | 上传所需的 file | - |
 
 ### Events
 

--- a/src/packages/__VUE/uploader/doc.taro.md
+++ b/src/packages/__VUE/uploader/doc.taro.md
@@ -282,8 +282,8 @@ const clearUpload = () => {
 | uid | 文件的唯一标识 | `new Date().getTime().toString()` |
 | name | 文件名称 | - |
 | url | 文件路径 | - |
-| formData | 上传所需的 data | `{}` |
 | percentage | 上传百分比 | `0` |
+| sourceFile | 上传所需的 file（仅WEB） | - |
 
 ### Events
 

--- a/src/packages/__VUE/uploader/index.taro.vue
+++ b/src/packages/__VUE/uploader/index.taro.vue
@@ -281,10 +281,21 @@ export default create({
 
     const executeUpload = (fileItem: FileItem, index: number) => {
       const uploadOption = new UploadOptions()
+
+      if (Taro.getEnv() == 'WEB') {
+        const formData = new FormData()
+        for (const [key, value] of Object.entries(props.data)) {
+          formData.append(key, value)
+        }
+        formData.append(props.name, fileItem.sourceFile!)
+        uploadOption.formData = formData
+      } else {
+        uploadOption.formData = props.data as FormData
+      }
+
       uploadOption.name = props.name
       uploadOption.url = props.url
       uploadOption.fileType = fileItem.type
-      uploadOption.formData = fileItem.formData
       uploadOption.timeout = (props.timeout as number) * 1
       uploadOption.method = props.method
       uploadOption.xhrState = props.xhrState as number
@@ -381,18 +392,13 @@ export default create({
         fileItem.status = 'ready'
         fileItem.message = translate('waitingUpload')
         fileItem.type = fileType
+
         if (Taro.getEnv() == 'WEB') {
-          const formData = new FormData()
-          for (const [key, value] of Object.entries(props.data)) {
-            formData.append(key, value)
-          }
-          formData.append(props.name, file.originalFileObj as Blob)
+          fileItem.sourceFile = file.originalFileObj
           fileItem.name = file.originalFileObj?.name
           fileItem.type = file.originalFileObj?.type
-          fileItem.formData = formData
-        } else {
-          fileItem.formData = props.data
         }
+
         if (props.isPreview) {
           fileItem.url = fileType == 'video' ? file.thumbTempFilePath : filepath
         }

--- a/src/packages/__VUE/uploader/index.vue
+++ b/src/packages/__VUE/uploader/index.vue
@@ -185,20 +185,22 @@ export default create({
     }
 
     const executeUpload = (fileItem: FileItem, index: number) => {
+      const formData = new FormData()
+      for (const [key, value] of Object.entries(props.data)) {
+        formData.append(key, value)
+      }
+      formData.append(props.name, fileItem.sourceFile!)
+
       const uploadOption = new UploadOptions()
       uploadOption.url = props.url
-      uploadOption.formData = fileItem.formData
+      uploadOption.formData = formData
       uploadOption.timeout = (props.timeout as number) * 1
       uploadOption.method = props.method
       uploadOption.xhrState = props.xhrState as number
       uploadOption.headers = props.headers
       uploadOption.withCredentials = props.withCredentials
       uploadOption.beforeXhrUpload = props.beforeXhrUpload
-      try {
-        uploadOption.sourceFile = fileItem.formData.get(props.name)
-      } catch (error) {
-        console.warn('[NutUI] <Uploader> formData.get(name)', error)
-      }
+      uploadOption.sourceFile = fileItem.sourceFile
       uploadOption.onStart = (option: UploadOptions) => {
         fileItem.status = 'ready'
         fileItem.message = translate('readyUpload')
@@ -260,17 +262,11 @@ export default create({
 
     const readFile = (files: File[]) => {
       files.forEach((file: File, index: number) => {
-        const formData = new FormData()
-        for (const [key, value] of Object.entries(props.data)) {
-          formData.append(key, value)
-        }
-        formData.append(props.name, file)
-
         const fileItem = reactive(new FileItem())
         fileItem.name = file.name
         fileItem.status = 'ready'
         fileItem.type = file.type
-        fileItem.formData = formData
+        fileItem.sourceFile = file
         fileItem.message = translate('waitingUpload')
         executeUpload(fileItem, index)
 

--- a/src/packages/__VUE/uploader/type.ts
+++ b/src/packages/__VUE/uploader/type.ts
@@ -11,5 +11,5 @@ export class FileItem {
   type?: string
   path?: string
   percentage: string | number = 0
-  formData: any = {}
+  sourceFile?: File
 }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/jdf2e/nutui/issues/1671
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

修复uploader的 `data` 参数外部修改后提交时仍然是选择文件时的旧值问题 #3064

**这个 PR 是什么类型?** (至少选择一个)

- [ ] feat: 新特性提交
- [x] fix: bug 修复
- [ ] docs: 文档改进
- [ ] style: 组件样式/交互改进
- [ ] type: 类型定义更新
- [ ] perf: 性能、包体积优化
- [ ] refactor: 代码重构、代码风格优化
- [ ] test: 测试用例
- [ ] chore(deps): 依赖升级
- [ ] chore(demo): 演示代码改进
- [ ] chore(locale): 国际化改进
- [ ] chore: 其他改动（是关于什么的改动？）

**这个 PR 涉及以下平台:**

- [x] NutUI H5 @nutui/nutui
- [x] NutUI Taro @nutui/nutui-taro

**这个 PR 是否已自测:**

- [x] 自测 Vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/vite)
- [x] 自测 Taro 脚手架使用小程序 & Taro-H5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/taro)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 更新了`Uploader`组件的文档，增加了新属性、事件和方法。
	- 新增`maximize`、`before-upload`和`before-xhr-upload`属性。
	- 新增`oversize`事件，用于处理超出文件大小限制的情况。
	- `FileItem`接口中新增`sourceFile`属性，替代了`formData`属性。
- **文档**
	- 增强了API部分的描述，提供了详细的属性、事件和方法信息。
	- 添加了示例，展示新功能的使用方法，如自定义上传样式和手动上传触发。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->