### PR TITLE
fix(menu): 修复点击菜单无法正常切换的问题

### DIFF
--- a/src/packages/__VUE/menu/index.scss
+++ b/src/packages/__VUE/menu/index.scss
@@ -23,7 +23,10 @@
     display: flex;
     line-height: $menu-bar-line-height;
     background-color: $white;
-    box-shadow: $menu-bar-box-shadow;
+
+    &:not(.opened) {
+      box-shadow: $menu-bar-box-shadow;
+    }
 
     &.opened {
       z-index: $menu-bar-opened-z-index;

--- a/src/packages/__VUE/menuitem/index.scss
+++ b/src/packages/__VUE/menuitem/index.scss
@@ -10,7 +10,7 @@
 
 .nut-menu-item {
   position: fixed;
-  z-index: $menu-bar-opened-z-index;
+  z-index: calc($menu-bar-opened-z-index - 1);
   left: 0;
   right: 0;
   height: 100vh;
@@ -55,6 +55,6 @@
   position: fixed;
   left: 0;
   right: 0;
-  z-index: $menu-bar-opened-z-index;
+  z-index: calc($menu-bar-opened-z-index - 1);
   background-color: transparent;
 }


### PR DESCRIPTION
**这个 PR 做了什么?**
修复了 Menu 组件切换菜单时的交互问题，主要解决了：
1. 修复向下展开菜单需要点击两次才能切换的问题（调整遮罩层 z-index）
2. 修复向上展开菜单点击空白处无法关闭的问题（修正遮罩层定位）
3. 优化菜单展开时的样式表现

**这个 PR 是什么类型?**
- [ ] feat: 新特性提交
- [x] fix: bug 修复
- [ ] docs: 文档改进
- [x] style: 组件样式/交互改进
- [ ] type: 类型定义更新
- [ ] perf: 性能、包体积优化
- [ ] refactor: 代码重构、代码风格优化
- [ ] test: 测试用例
- [ ] chore(deps): 依赖升级
- [ ] chore(demo): 演示代码改进
- [ ] chore(locale): 国际化改进
- [ ] chore: 其他改动

**这个 PR 涉及以下平台:**
- [x] NutUI H5 @nutui/nutui
- [x] NutUI Taro @nutui/nutui-taro

**这个 PR 是否已自测:**
- [x] 自测 Vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/vite)
- [x] 自测 Taro 脚手架使用小程序 & Taro-H5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/taro)