### PR TITLE
fix: 修复当 popup 初始化是 props.visible=true 的时候，无法关闭 popup 组件问题

### DIFF
--- a/src/packages/__VUE/popup/index.taro.vue
+++ b/src/packages/__VUE/popup/index.taro.vue
@@ -2,8 +2,8 @@
   <view>
     <nut-overlay v-if="overlay" :visible="visible" :close-on-click-overlay="closeOnClickOverlay" :z-index="zIndex"
                  :lock-scroll="lockScroll" :duration="duration" :overlay-class="overlayClass" :overlay-style="overlayStyle"
-                 v-bind="$attrs" @click="onClickOverlay" />
-    <Transition :name="transitionName" @after-enter="onOpened" @after-leave="onClosed">
+                 v-bind="$attrs" appear @click="onClickOverlay" />
+    <Transition appear :name="transitionName" @after-enter="onOpened" @after-leave="onClosed">
       <view v-show="visible" :class="classes" :style="popStyle" @click="onClick">
         <slot v-if="showSlot"></slot>
         <view v-if="closed" class="nut-popup__close-icon" :class="'nut-popup__close-icon--' + closeIconPosition"
@@ -128,6 +128,9 @@ export default create({
         if (!props.visible && opened) {
           close()
         }
+      },
+      {
+        immediate: true
       }
     )
     watchEffect(() => {

--- a/src/packages/__VUE/popup/index.vue
+++ b/src/packages/__VUE/popup/index.vue
@@ -2,8 +2,8 @@
   <Teleport :to="teleport" :disabled="!teleportDisable">
     <nut-overlay v-if="overlay" :visible="visible" :close-on-click-overlay="closeOnClickOverlay" :z-index="zIndex"
                  :lock-scroll="lockScroll" :duration="duration" :overlay-class="overlayClass" :overlay-style="overlayStyle"
-                 v-bind="$attrs" @click="onClickOverlay" />
-    <Transition :name="transitionName" @after-enter="onOpened" @after-leave="onClosed">
+                 v-bind="$attrs" appear @click="onClickOverlay" />
+    <Transition appear :name="transitionName" @after-enter="onOpened" @after-leave="onClosed">
       <view v-show="visible" :class="classes" :style="popStyle" @click="onClick">
         <slot v-if="showSlot"></slot>
         <view v-if="closed" class="nut-popup__close-icon" :class="'nut-popup__close-icon--' + closeIconPosition"
@@ -128,6 +128,9 @@ export default create({
         if (!props.visible && opened) {
           close()
         }
+      },
+      {
+        immediate: true
       }
     )
     watchEffect(() => {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/jdf2e/nutui/issues/1671
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

修复当 popup 初始化是 props.visible=true 的时候，无法关闭 popup 组件问题，并优化支持首次打开的过渡效果

复现地址：https://nutui.jd.com/playground/#eyJBcHAudnVlIjoiPHRlbXBsYXRlPlxuICA8bnV0LWNlbGwgdGl0bGU9XCJDZW50ZXJcIiBpcy1saW5rIEBjbGljaz1cInNob3cgPSB0cnVlXCI+PC9udXQtY2VsbD5cbiAgPG51dC1wb3B1cCB2LW1vZGVsOnZpc2libGU9XCJzaG93XCIgOnN0eWxlPVwieyBwYWRkaW5nOiAnMzBweCA1MHB4JyB9XCI+IOato+aWhyA8L251dC1wb3B1cD5cbjwvdGVtcGxhdGU+XG48c2NyaXB0IHNldHVwPlxuaW1wb3J0IHsgcmVmIH0gZnJvbSAndnVlJ1xuY29uc3Qgc2hvdyA9IHJlZih0cnVlKVxuPC9zY3JpcHQ+In0=


**这个 PR 是什么类型?** (至少选择一个)

- [ ] feat: 新特性提交
- [x] fix: bug 修复
- [ ] docs: 文档改进
- [x] style: 组件样式/交互改进
- [ ] type: 类型定义更新
- [ ] perf: 性能、包体积优化
- [ ] refactor: 代码重构、代码风格优化
- [ ] test: 测试用例
- [ ] chore(deps): 依赖升级
- [ ] chore(demo): 演示代码改进
- [ ] chore(locale): 国际化改进
- [ ] chore: 其他改动（是关于什么的改动？）

**这个 PR 涉及以下平台:**

- [x] NutUI H5 @nutui/nutui
- [x] NutUI Taro @nutui/nutui-taro

**这个 PR 是否已自测:**

- [x] 自测 Vite 脚手架使用 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/vite)
- [x] 自测 Taro 脚手架使用小程序 & Taro-H5 [测试仓库](https://github.com/jdf2e/nutui-demo/tree/dev/taro)
