### PR TITLE
feat(input): 输入框类型为password时增加显示隐藏密码功能

### DIFF
--- a/src/packages/__VUE/input/index.scss
+++ b/src/packages/__VUE/input/index.scss
@@ -122,6 +122,13 @@ textarea {
     cursor: pointer;
     margin: 0 4px;
   }
+  &-eye {
+    width: 16px;
+    height: 16px;
+    color: #000;
+    cursor: pointer;
+    margin: 0 4px;
+  }
   &--required {
     &::before {
       position: absolute;

--- a/src/packages/__VUE/input/input.vue
+++ b/src/packages/__VUE/input/input.vue
@@ -44,6 +44,10 @@
             </MaskClose>
           </slot>
         </view>
+        <view v-if="type === 'password' && !readonly" class="nut-input-eye">
+          <Marshalling v-if="isPassword" v-bind="$attrs" size="15" @click="updateStatus"> </Marshalling>
+          <Eye v-else v-bind="$attrs" size="15" @click="updateStatus"> </Eye>
+        </view>
         <view class="nut-input-right-box">
           <slot name="right"> </slot>
         </view>
@@ -53,7 +57,7 @@
 </template>
 <script setup lang="ts">
 import { ref, reactive, computed, onMounted, watch, ComputedRef, h, toRef } from 'vue'
-import { MaskClose } from '@nutui/icons-vue'
+import { MaskClose, Marshalling, Eye } from '@nutui/icons-vue'
 import { formatNumber, mapInputType } from './util'
 import { useFormDisabled } from '../form/common'
 
@@ -109,9 +113,15 @@ const emit = defineEmits(['update:modelValue', 'blur', 'focus', 'clear', 'keypre
 const disabled = useFormDisabled(toRef(props, 'disabled'))
 const active = ref(false)
 const inputRef = ref()
+const isPassword = ref(true)
 const getModelValue = () => String(props.modelValue ?? '')
 
-const renderInput = (type: InputType) => h('input', { ...mapInputType(type) })
+const renderInput = (type: InputType) => {
+  if (type === 'password') {
+    return h('input', { ...mapInputType(isPassword.value ? 'password' : 'text') })
+  }
+  return h('input', { ...mapInputType(type) })
+}
 
 const state = reactive({
   focused: false,
@@ -209,6 +219,12 @@ const resetValidation = () => {
   }
 }
 
+const updateStatus = () => {
+  console.log('updateStatus', isPassword.value)
+
+  isPassword.value = !isPassword.value
+}
+
 const onClickInput = (event: MouseEvent) => {
   if (disabled.value) {
     return
@@ -221,12 +237,12 @@ const onClick = (event: MouseEvent) => {
 }
 
 const startComposing = ({ target }: Event) => {
-  (target as InputTarget)!.composing = true
+  ;(target as InputTarget)!.composing = true
 }
 
 const endComposing = ({ target }: Event) => {
   if ((target as InputTarget)!.composing) {
-    (target as InputTarget)!.composing = false
+    ;(target as InputTarget)!.composing = false
     ;(target as InputTarget)!.dispatchEvent(new Event('input'))
   }
 }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/jd-opensource/nutui/issues/1671
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
h5的vue版本的密码输入框默认是加密的，
我这里在密码输入框右侧增加了加密解密的icon，点击可以控制密码是否私密，默认加密。


**这个 PR 是什么类型?** (至少选择一个)

- [x] feat: 新特性提交
- [ ] fix: bug 修复
- [ ] docs: 文档改进
- [x] style: 组件样式/交互改进
- [ ] type: 类型定义更新
- [ ] perf: 性能、包体积优化
- [ ] refactor: 代码重构、代码风格优化
- [ ] test: 测试用例
- [ ] chore(deps): 依赖升级
- [ ] chore(demo): 演示代码改进
- [ ] chore(locale): 国际化改进
- [ ] chore: 其他改动（是关于什么的改动？）

**这个 PR 涉及以下平台:**

- [x] NutUI H5 @nutui/nutui
- [ ] NutUI Taro @nutui/nutui-taro

**这个 PR 是否已自测:**

- [x] 自测 Vite 脚手架使用 [测试仓库](https://github.com/jd-opensource/nutui-demo/tree/dev/vite)
- [ ] 自测 Taro 脚手架使用小程序 & Taro-H5 [测试仓库](https://github.com/jd-opensource/nutui-demo/tree/dev/taro)
