### PR TITLE
feat(ascf): 支持ASCF鸿蒙元服务

### DIFF
--- a/src/packages/__VUE/signature/index.taro.vue
+++ b/src/packages/__VUE/signature/index.taro.vue
@@ -164,7 +164,7 @@ export default create({
     onMounted(() => {
       Taro.nextTick(() => {
         setTimeout(() => {
-          if (['WEAPP', 'JD', 'TT', 'SWAN', 'ALIPAY', 'QQ'].includes(Taro.getEnv())) {
+          if (['WEAPP', 'JD', 'TT', 'SWAN', 'ALIPAY', 'QQ', 'ASCF'].includes(Taro.getEnv())) {
             Taro.createSelectorQuery()
               .select('#' + canvasSetId)
               .fields(

--- a/src/packages/__VUE/uploader/index.taro.vue
+++ b/src/packages/__VUE/uploader/index.taro.vue
@@ -198,8 +198,8 @@ export default create({
           document.body.appendChild(obj)
         }
       }
-      if (Taro.getEnv() == 'WEAPP') {
-        // chooseMedia 目前只支持微信小程序原生，其余端全部使用 chooseImage API
+      if (['WEAPP', 'ASCF'].includes(Taro.getEnv())) {
+        // chooseMedia 目前只支持微信小程序原生和ASCF，其余端全部使用 chooseImage API
         Taro.chooseMedia({
           /** 最多可以选择的文件个数 */
           count: props.multiple ? Number(props.maximum) - fileList.value.length : 1,


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/jd-opensource/nutui/issues/1671
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
Taro已支持编译ASCF元服务，配套UI组件库也适配一下：[ASCF元服务](https://nervjs.github.io/taro-docs/docs/GETTING-STARTED#ascf-%E5%85%83%E6%9C%8D%E5%8A%A1)

适配后的运行效果如下：

Signature签名 组件：

![Screenshot_20251209095956616](https://github.com/user-attachments/assets/93a4bb71-6fa1-4ff5-9077-837c4abdacfd)



Uploader上传 组件：

![Screenshot_20251208151329140](https://github.com/user-attachments/assets/af0a67d5-5f37-4a03-8a3c-543586455585)


**这个 PR 是什么类型?** (至少选择一个)

- [x] feat: 新特性提交
- [ ] fix: bug 修复
- [ ] docs: 文档改进
- [ ] style: 组件样式/交互改进
- [ ] type: 类型定义更新
- [ ] perf: 性能、包体积优化
- [ ] refactor: 代码重构、代码风格优化
- [ ] test: 测试用例
- [ ] chore(deps): 依赖升级
- [ ] chore(demo): 演示代码改进
- [ ] chore(locale): 国际化改进
- [ ] chore: 其他改动（是关于什么的改动？）

**这个 PR 涉及以下平台:**

- [ ] NutUI H5 @nutui/nutui
- [x] NutUI Taro @nutui/nutui-taro

**这个 PR 是否已自测:**

- [x] 自测 Vite 脚手架使用 [测试仓库](https://github.com/jd-opensource/nutui-demo/tree/dev/vite)
- [x] 自测 Taro 脚手架使用小程序 & Taro-H5 [测试仓库](https://github.com/jd-opensource/nutui-demo/tree/dev/taro)
