### PR TITLE
fix(calendar-item): 修复容器高度小于选择器高度时，位置计算错误问题

### DIFF
--- a/src/packages/__VUE/calendaritem/index.vue
+++ b/src/packages/__VUE/calendaritem/index.vue
@@ -778,7 +778,7 @@ export default create({
           current -= 1
         }
       } else {
-        const viewPosition = Math.round(currentScrollTop + viewHeight.value)
+        const viewPosition = Math.round(currentScrollTop + Math.max(viewHeight.value, state.monthsData[current].cssHeight))  
         if (
           viewPosition < state.monthsData[current].cssScrollHeight + state.monthsData[current].cssHeight
           && currentScrollTop > state.monthsData[current - 1].cssScrollHeight


### PR DESCRIPTION
viewHeight.value 为容器高度，当容器恰好比当前选中月份高度低时，会导致 `viewPosition < state.monthsData[current].cssScrollHeight + state.monthsData[current].cssHeight` 始终为 true 。从而导致滚动位置偏差一个月。

**这个 PR 做了什么?** (简要描述所做更改)
修复当 calendar-item 容器高度比当前选中月份高度低时，无法正确定位到选中项的问题。
![iShot_2026-01-19_17 01 12](https://github.com/user-attachments/assets/8d500b52-ab1b-4e6d-a289-6f6e3c9bc696)


**这个 PR 是什么类型?** (至少选择一个)

- [ ] feat: 新特性提交
- [x] fix: bug 修复
- [ ] docs: 文档改进
- [ ] style: 组件样式/交互改进
- [ ] type: 类型定义更新
- [ ] perf: 性能、包体积优化
- [ ] refactor: 代码重构、代码风格优化
- [ ] test: 测试用例
- [ ] chore(deps): 依赖升级
- [ ] chore(demo): 演示代码改进
- [ ] chore(locale): 国际化改进
- [ ] chore: 其他改动（是关于什么的改动？）

**这个 PR 涉及以下平台:**

- [x] NutUI H5 @nutui/nutui
- [ ] NutUI Taro @nutui/nutui-taro

**这个 PR 是否已自测:**

- [ ] 自测 Vite 脚手架使用 [测试仓库](https://github.com/jd-opensource/nutui-demo/tree/dev/vite)
- [ ] 自测 Taro 脚手架使用小程序 & Taro-H5 [测试仓库](https://github.com/jd-opensource/nutui-demo/tree/dev/taro)
