### PR TITLE
docs(dialog): 添加 zIndex 参数以支持自定义弹框层级

### DIFF
--- a/src/packages/__VUE/dialog/doc.md
+++ b/src/packages/__VUE/dialog/doc.md
@@ -211,6 +211,7 @@ const teleportClick = (teleport) => {
 | overlayStyle | 自定义遮罩样式 | CSSProperties | - |
 | popClass | 自定义 `popup` 弹框类名 | string | - |
 | popStyle | 自定义 `popup` 弹框样式 | CSSProperties | - |
+| zIndex | 自定义 `popup` 层级 | string \| number | 2000 |
 | onUpdate | 更新 | boolean | `false` |
 | onOk | 确定按钮回调 | Function | - |
 | onCancel | 取消按钮回调 | Function | - |


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/jd-opensource/nutui/issues/1671
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
更新文档

**这个 PR 是什么类型?** (至少选择一个)

- [ ] feat: 新特性提交
- [ ] fix: bug 修复
- [x] docs: 文档改进
- [ ] style: 组件样式/交互改进
- [ ] type: 类型定义更新
- [ ] perf: 性能、包体积优化
- [ ] refactor: 代码重构、代码风格优化
- [ ] test: 测试用例
- [ ] chore(deps): 依赖升级
- [ ] chore(demo): 演示代码改进
- [ ] chore(locale): 国际化改进
- [ ] chore: 其他改动（是关于什么的改动？）

**这个 PR 涉及以下平台:**

- [x] NutUI H5 @nutui/nutui
- [ ] NutUI Taro @nutui/nutui-taro

**这个 PR 是否已自测:**

- [x] 自测 Vite 脚手架使用 [测试仓库](https://github.com/jd-opensource/nutui-demo/tree/dev/vite)
- [x] 自测 Taro 脚手架使用小程序 & Taro-H5 [测试仓库](https://github.com/jd-opensource/nutui-demo/tree/dev/taro)
