### PR TITLE
docs(shortpassword): add tips event documentation

### DIFF
--- a/src/packages/__VUE/shortpassword/__tests__/index.spec.ts
+++ b/src/packages/__VUE/shortpassword/__tests__/index.spec.ts
@@ -24,3 +24,15 @@ test('should emit complete when finish input', async () => {
   await nextTick()
   expect(wrapper.emitted().complete[0]).toEqual(['321123'])
 })
+
+test('should emit tips when clicking tips text', async () => {
+  const wrapper = mount(ShortPassword, {
+    props: {
+      visible: true,
+      tips: '忘记密码'
+    }
+  })
+  const tipsEl = wrapper.find('.nut-short-password--forget')
+  await tipsEl.trigger('click')
+  expect(wrapper.emitted().tips).toBeTruthy()
+})

--- a/src/packages/__VUE/shortpassword/doc.en-US.md
+++ b/src/packages/__VUE/shortpassword/doc.en-US.md
@@ -53,6 +53,7 @@ app.use(NumberKeyboard)
 | close | Trigger an event when the close icon is clicked | - |
 | complete | Input complete callback | `value:string` |
 | focus | Emitted when input is focused | - |
+| tips | Emitted when tips is clicked | - |
 
 ## Theming
 

--- a/src/packages/__VUE/shortpassword/doc.md
+++ b/src/packages/__VUE/shortpassword/doc.md
@@ -53,6 +53,7 @@ app.use(NumberKeyboard)
 | close | 点击关闭图标时触发事件 | - |
 | complete | 输入完成的回调 | `value:string` |
 | focus | 输入框聚焦时触发 | - |
+| tips | 点击提示语时触发 | - |
 
 ## 主题定制
 

--- a/src/packages/__VUE/shortpassword/doc.taro.md
+++ b/src/packages/__VUE/shortpassword/doc.taro.md
@@ -53,6 +53,7 @@ app.use(NumberKeyboard)
 | close | 点击关闭图标或者遮罩时触发事件 | - |
 | complete | 输入完成的回调 | `value:string` |
 | focus | 输入框聚焦时触发 | - |
+| tips | 点击提示语时触发 | - |
 
 ## 主题定制
 


### PR DESCRIPTION
## What is the problem?

The \ShortPassword\ component already supports the \	ips\ event (clicking the tips text), but this event is not documented in the API section. This may confuse users who want to handle the tips click event.

## How did I fix it?

- Added \	ips\ event documentation to \doc.md\, \doc.taro.md\, and \doc.en-US.md\
- Added unit test for the \	ips\ event

## How was this tested?

- Added unit test: \src/packages/__VUE/shortpassword/__tests__/index.spec.ts\

Closes #2945